### PR TITLE
[composer] Require symfony 2.1.* instead of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
   , "require": {
         "php": ">=5.3.2"
       , "guzzle/guzzle": "v2.0.2"
-      , "symfony/http-foundation": "dev-master"
+      , "symfony/http-foundation": "2.1.*"
     }
 }


### PR DESCRIPTION
This allows using ratchet with a forked version of symfony.

Please merge master into the socket-server branch after merging.
