### PR TITLE
Update server socket connection event name to "connection" from "connect" since React was changed.

### DIFF
--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -41,7 +41,7 @@ class IoServer {
         $this->loop = $loop;
         $this->app  = $app;
 
-        $socket->on('connect', array($this, 'handleConnect'));
+        $socket->on('connection', array($this, 'handleConnect'));
 
         $this->handlers['data']  = array($this, 'handleData');
         $this->handlers['end']   = array($this, 'handleEnd');


### PR DESCRIPTION
It looks like they changed the socket connection event name at https://github.com/react-php/react/commit/70bc398270c8dc8f2cb8e7b9fbf2dbbf96599fd2 . My app quit working after a `composer update` and I just got lucky to come across that commit. Changing the name to 'connection' fixed everything for me.
