### PR TITLE
Ratchet does not work with guzzle/http 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   , "require": {
         "php": ">=5.3.3"
       , "react/socket": "0.2.*"
-      , "guzzle/http": "~3.0"
+      , "guzzle/http": ">=3.0,<=3.5"
       , "symfony/http-foundation": "~2.1"
     }
 }


### PR DESCRIPTION
Getting this error
Object of class Guzzle\Http\Message\Header could not be converted to int
