### PR TITLE
Fixed type conversion issue with isProtocol method in RFC6455

### DIFF
--- a/src/Ratchet/WebSocket/Version/RFC6455.php
+++ b/src/Ratchet/WebSocket/Version/RFC6455.php
@@ -50,7 +50,7 @@ class RFC6455 implements VersionInterface {
      * {@inheritdoc}
      */
     public function isProtocol(RequestInterface $request) {
-        $version = (int)$request->getHeader('Sec-WebSocket-Version', -1);
+        $version = (int)((string)($request->getHeader('Sec-WebSocket-Version', -1)));
 
         return ($this->getVersionNumber() === $version);
     }


### PR DESCRIPTION
I encountered the following error while attempting to use Ratchet. The __toString version of the request contained the correct value (13), so I cast the result to a string before casting it to an integer. 

Notice: Object of class Guzzle\Http\Message\Header could not be converted to int in [file system path]\vendor\cboden\ratchet\src\Ratchet\WebSocket\Version\RFC6455.php on line 53
