### PR TITLE
Fixed type conversion issue with isProtocol method in HyBi10.php

### DIFF
--- a/src/Ratchet/WebSocket/Version/HyBi10.php
+++ b/src/Ratchet/WebSocket/Version/HyBi10.php
@@ -4,7 +4,7 @@ use Guzzle\Http\Message\RequestInterface;
 
 class HyBi10 extends RFC6455 {
     public function isProtocol(RequestInterface $request) {
-        $version = (int)$request->getHeader('Sec-WebSocket-Version', -1);
+        $version = (int)((string)($request->getHeader('Sec-WebSocket-Version', -1)));
         return ($version >= 6 && $version < 13);
     }
 


### PR DESCRIPTION
I encountered the following error while attempting to use Ratchet. The __toString version of the request should contain the proper value, and retrieving the string before converting to an int would prevent this typecasting issue.

Notice: Object of class Guzzle\Http\Message\Header could not be converted to int in [file system path]\vendor\cboden\ratchet\src\Ratchet\WebSocket\Version\HyBi10.php on line 7
