### PR TITLE
composers autoload order for compatibility with TYPO3 Flow framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     }
   , "autoload": {
         "psr-0": {
+            "Ratchet": "src",
             "Ratchet\\Tests": "tests"
-          , "Ratchet": "src"
         }
     }
   , "require": {


### PR DESCRIPTION
This small change allow using the cboden/Ratchet out of the box with TYPO3 Flow.

Unfortunately TYPO3 Flow can not load second entry given in the manifest for autoloading (Source: http://docs.typo3.org/flow/TYPO3FlowDocumentation/stable/TheDefinitiveGuide/PartIII/PackageManagement.html#using-3rd-party-packages )

Only one of both tricks is needed in Flow's Settings.yaml:

:1. excluding annotations

<pre>
TYPO3:
  Flow:
    reflection:
      ignoredTags: ['event', 'temporary', 'type', 'note']
</pre>

:2. excluding this package from Object Framework (Note: this makes AOP for Ratchet off)

<pre>
TYPO3:
  Flow:
    object:
      excludeClasses:
        'cboden.Ratchet': ['Ratchet\\.*']
</pre>

).
