### PR TITLE
This modification gives Ratchet its own RequestFactory instance.

### DIFF
--- a/src/Ratchet/Http/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Ratchet/Http/Guzzle/Http/Message/RequestFactory.php
@@ -4,6 +4,23 @@ use Guzzle\Http\Message\RequestFactory as GuzzleRequestFactory;
 use Guzzle\Http\EntityBody;
 
 class RequestFactory extends GuzzleRequestFactory {
+
+    protected static $ratchetInstance;
+    
+    /**
+     * {@inheritdoc}
+     */
+    public static function getInstance()
+    {
+        // @codeCoverageIgnoreStart
+        if (!static::$ratchetInstance) {
+            static::$ratchetInstance = new static();
+        }
+        // @codeCoverageIgnoreEnd
+
+        return static::$ratchetInstance;
+    }
+		
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This modification gives Ratchet its own RequestFactory instance.
This way you can use guzzle as REST Client in your ratchet project.

The problem was : 
Ratchet extends the guzzle request factory and override the create method for its own needs.
But the request factory is a singleton therefore you can't use the Guzzle library anymore for something else (example : REST Client).
With this fix, Ratchet gets its own singleton of the request factory and leaves the default singleton intact.
