### PR TITLE
Make WampServer’s $wampProtocol protected to afford inheritance of the \Ratchet\Wamp\WampServer class

### DIFF
--- a/src/Ratchet/Wamp/WampServer.php
+++ b/src/Ratchet/Wamp/WampServer.php
@@ -15,7 +15,7 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
     /**
      * @var ServerProtocol
      */
-    private $wampProtocol;
+    protected $wampProtocol;
 
     /**
      * This class just makes it 1 step easier to use Topic objects in WAMP


### PR DESCRIPTION
If `$wampProtocol` is `protected` one can implement [other WebSocket Subprotocols](http://www.iana.org/assignments/websocket/websocket.xhtml#subprotocol-name) which are based upon WAMP by extending some of the `\Ratchet\Wamp` classes.

Example: `ocpp1.5` is inspired upon WAMP ([spec](http://www.gir.fr/ocppjs/ocpp_srpc_spec.shtml)). The most easy way to implement this is to:
- Define a custom `ServerProtocol` (inspired upon `\Ratchet\Wamp\ServerProtocol`)
- Use that protocol in `\Ratchet\Wamp\WampServer` by extending the class and overriding the constructor

It's this second step in this process which requires `$wampProtocol` to be `protected` in order to work.
