### PR TITLE
[Router] Update the request object with parameters of the route

### DIFF
--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -3,6 +3,7 @@ namespace Ratchet\Http;
 use Ratchet\ConnectionInterface;
 use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Http\Message\Response;
+use Guzzle\Http\Url;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -45,6 +46,16 @@ class Router implements HttpServerInterface {
         if (!($route['_controller'] instanceof HttpServerInterface)) {
             throw new \UnexpectedValueException('All routes must implement Ratchet\Http\HttpServerInterface');
         }
+        
+        $parameters = array();
+        foreach($route as $key => $value) {
+            if (!in_array($key, array('_controller', '_route'))) {
+                $parameters[$key] = $value;
+            }
+        }
+        $url = Url::factory($request->getPath());
+        $url->setQuery($parameters);
+        $request->setUrl($url);
 
         $conn->controller = $route['_controller'];
         $conn->controller->onOpen($conn, $request);


### PR DESCRIPTION
Update the Url QueryString of the request object with the parameters return by the UrlMatcher to let the developer access thoses parameters.

The user can simply access the parameters via the Query String of the request object :

``` php
public function onOpen(ConnectionInterface $conn) {
    print_r($conn->WebSocket->request->getQuery());
}
```

fixes #141 
