### PR TITLE
gc_enable is not called if running with HHVM

### DIFF
--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -33,7 +33,10 @@ class IoServer {
      * @param \React\EventLoop\LoopInterface|null $loop     The React looper to run the Ratchet application off of
      */
     public function __construct(MessageComponentInterface $app, ServerInterface $socket, LoopInterface $loop = null) {
-        gc_enable();
+        if (false === strpos(PHP_VERSION, "hiphop")) {
+            gc_enable();
+        }
+
         set_time_limit(0);
         ob_implicit_flush();
 


### PR DESCRIPTION
Since HHVM doesn't support garbage collector (for obvious reasons), the following patch make Ratchet works with HHVM as well.
