### PR TITLE
Added subscribers filtering in topic broadcasting

### DIFF
--- a/src/Ratchet/Wamp/Topic.php
+++ b/src/Ratchet/Wamp/Topic.php
@@ -36,14 +36,14 @@ class Topic implements \IteratorAggregate, \Countable {
       * @param array $eligible
       * @return Topic
       */
-    public function broadcast($msg, array $exclude, array $eligible) {
+    public function broadcast($msg, array $exclude = array(), array $eligible = array()) {
         $useEligible = count($eligible);
         foreach ($this->subscribers as $client) {
-            if(in_array($client->getSessionId(), $exclude)) {
+            if(in_array($client->WAMP->sessionId, $exclude)) {
                 continue;
             }
 
-            if($useEligible && !in_array($client->getSessionId(), $eligible)) {
+            if($useEligible && !in_array($client->WAMP->sessionId, $eligible)) {
                 continue;
             }
 

--- a/src/Ratchet/Wamp/WampConnection.php
+++ b/src/Ratchet/Wamp/WampConnection.php
@@ -100,10 +100,4 @@ class WampConnection extends AbstractConnectionDecorator {
         $this->getConnection()->close($opt);
     }
 
-	/**
-	 * Get session ID
-	 */
-	public function getSessionId() {
-		return $this->WAMP->sessionId;
-	}
 }

--- a/tests/unit/Wamp/TopicTest.php
+++ b/tests/unit/Wamp/TopicTest.php
@@ -57,7 +57,7 @@ class TopicTest extends \PHPUnit_Framework_TestCase {
         $topic->add($first);
         $topic->add($second);
 
-        $topic->broadcast($msg, array(), array());
+        $topic->broadcast($msg);
     }
 
     public function testIterator() {


### PR DESCRIPTION
Hi!
I'm developing a new WAMP JS client, and on my attempts to test it, i've found that broadcasting a topic doesn't take into account $exclude & $eligible options, and topic is sent to all subscribers, no matter what is specified in $exclude & $eligible options. This is a fix. Correct me if i am wrong, or forgot somethin.
