### PR TITLE
[Sessions] Decouple interface from WS, align with HTTP

### DIFF
--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -39,13 +39,13 @@ class SessionProvider implements HttpServerInterface {
     protected $_serializer;
 
     /**
-     * @param \Ratchet\MessageComponentInterface          $app
+     * @param \Ratchet\HttpServerInterface                $app
      * @param \SessionHandlerInterface                    $handler
      * @param array                                       $options
      * @param \Ratchet\Session\Serialize\HandlerInterface $serializer
      * @throws \RuntimeException
      */
-    public function __construct(MessageComponentInterface $app, \SessionHandlerInterface $handler, array $options = array(), HandlerInterface $serializer = null) {
+    public function __construct(HttpServerInterface $app, \SessionHandlerInterface $handler, array $options = array(), HandlerInterface $serializer = null) {
         $this->_app     = $app;
         $this->_handler = $handler;
         $this->_null    = new NullSessionHandler;
@@ -91,7 +91,7 @@ class SessionProvider implements HttpServerInterface {
             $conn->Session->start();
         }
 
-        return $this->_app->onOpen($conn);
+        return $this->_app->onOpen($conn, $request);
     }
 
     /**

--- a/tests/unit/Session/SessionComponentTest.php
+++ b/tests/unit/Session/SessionComponentTest.php
@@ -33,7 +33,7 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
     }
 
     public function getComponentClassString() {
-        return '\Ratchet\MessageComponentInterface';
+        return '\Ratchet\Http\HttpServerInterface';
     }
 
     public function classCaseProvider() {
@@ -51,7 +51,7 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
         $method = $ref->getMethod('toClassCase');
         $method->setAccessible(true);
 
-        $component = new SessionProvider($this->getMock('Ratchet\\MessageComponentInterface'), $this->getMock('\SessionHandlerInterface'));
+        $component = new SessionProvider($this->getMock($this->getComponentClassString()), $this->getMock('\SessionHandlerInterface'));
         $this->assertEquals($out, $method->invokeArgs($component, array($in)));
     }
 
@@ -77,7 +77,7 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
         $pdo->exec(vsprintf("CREATE TABLE %s (%s VARCHAR(255) PRIMARY KEY, %s TEXT, %s INTEGER)", $dbOptions));
         $pdo->prepare(vsprintf("INSERT INTO %s (%s, %s, %s) VALUES (?, ?, ?)", $dbOptions))->execute(array($sessionId, base64_encode('_sf2_attributes|a:2:{s:5:"hello";s:5:"world";s:4:"last";i:1332872102;}_sf2_flashes|a:0:{}'), time()));
 
-        $component  = new SessionProvider($this->getMock('Ratchet\\MessageComponentInterface'), new PdoSessionHandler($pdo, $dbOptions), array('auto_start' => 1));
+        $component  = new SessionProvider($this->getMock($this->getComponentClassString()), new PdoSessionHandler($pdo, $dbOptions), array('auto_start' => 1));
         $connection = $this->getMock('Ratchet\\ConnectionInterface');
 
         $headers = $this->getMock('Guzzle\\Http\\Message\\Request', array('getCookie'), array('POST', '/', array()));
@@ -110,6 +110,6 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
 
         ini_set('session.serialize_handler', 'wddx');
         $this->setExpectedException('\RuntimeException');
-        new SessionProvider($this->getMock('\Ratchet\MessageComponentInterface'), $this->getMock('\SessionHandlerInterface'));
+        new SessionProvider($this->getMock($this->getComponentClassString()), $this->getMock('\SessionHandlerInterface'));
     }
 }


### PR DESCRIPTION
This is technically a BC break so it's going in 0.4.

Before `HttpServer` was separated out from `WsServer` we read the HTTP headers from each `$conn->WebSocket->request` variable and assumed `SessionProvider` would sit on top of `WsServer`. Now with a cleaner separation `SessionProvider` should sit on top of `HttpServer` and below `WsServer`, being injected with the HTTP headers rather than assuming them inside a passed object. 

This is effectively removing cohesion from the `WebSocket` namespace and loosely coupling with the `Http` namespace, which makes more sense as PHP Sessions work at the HTTP layer using Cookies to maintain state. It is also doing it an explicit way with a declarative method signature rather than the previous implicit, assumed variable on an object. 
