### PR TITLE
Support bypassing Host check

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -107,7 +107,9 @@ class App {
             $decorated = $controller;
         }
 
-        $httpHost = $httpHost ?: $this->httpHost;
+        if ($httpHost === null) {
+            $httpHost = $this->httpHost;
+        }
 
         $allowedOrigins = array_values($allowedOrigins);
         if (0 === count($allowedOrigins)) {


### PR DESCRIPTION
An empty $httpHost can be passed to circumvent checking Host header.
