### PR TITLE
Consistent Exception handling for WAMP protocol errors

### DIFF
--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -90,7 +90,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
         }
 
         if (!is_array($json) || $json !== array_values($json)) {
-            throw new \UnexpectedValueException("Invalid WAMP message format");
+            throw new Exception("Invalid WAMP message format");
         }
 
         switch ($json[0]) {
@@ -134,7 +134,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
             break;
 
             default:
-                throw new Exception('Invalid message type');
+                throw new Exception('Invalid WAMP message type');
         }
     }
 

--- a/src/Ratchet/Wamp/WampServer.php
+++ b/src/Ratchet/Wamp/WampServer.php
@@ -39,7 +39,7 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
     public function onMessage(ConnectionInterface $conn, $msg) {
         try {
             $this->wampProtocol->onMessage($conn, $msg);
-        } catch (JsonException $je) {
+        } catch (Exception $je) {
             $conn->close(1007);
         } catch (\UnexpectedValueException $uve) {
             $conn->close(1007);


### PR DESCRIPTION
I've had to debug some WAMP protocol errors and found this to be difficult due to the inconsistent use of the `Wamp\Exception` class. After talking to @cboden we figured it might be worth submitting this really minor changeset as a PR.
