### PR TITLE
Open & close the session file

### DIFF
--- a/src/Ratchet/Session/Storage/VirtualSessionStorage.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorage.php
@@ -30,7 +30,17 @@ class VirtualSessionStorage extends NativeSessionStorage {
             return true;
         }
 
+        /** 
+         * Open the sessionfile first to avoid a PHP warning
+         * PHP Warning:  SessionHandler::read(): Parent session handler is not open
+         */
+        $this->saveHandler->open(ini_get('session.save_path'), $this->saveHandler->getId());
+        // Read the data from the file
         $rawData     = $this->saveHandler->read($this->saveHandler->getId());
+        /** Close the file so we wont have a write lock
+         * This would hang every other request of the client when not using the websocket server
+         */
+        $this->saveHandler->close();
         $sessionData = $this->_serializer->unserialize($rawData);
 
         $this->loadSession($sessionData);


### PR DESCRIPTION
Without first opening the session file, a PHP warning is thrown: 
PHP Warning:  SessionHandler::read(): Parent session handler is not open

After opening, read the data and directly close it to avoid a lock on the session file.