### PR TITLE
Update Router.php

### DIFF
--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -47,7 +47,7 @@ class Router implements HttpServerInterface {
             throw new \UnexpectedValueException('All routes must implement Ratchet\Http\HttpServerInterface');
         }
 
-        $parameters = array();
+        $parameters = $request->getUrl(true)->getQuery()->toArray();
         foreach($route as $key => $value) {
             if ((is_string($key)) && ('_' !== substr($key, 0, 1))) {
                 $parameters[$key] = $value;


### PR DESCRIPTION
Prefills request params with GET params (e.g. `/endpoint?a=b&c=d` produces `array('a' => 'b', 'c' => 'd')` instead of `array()`)
