### PR TITLE
Add handler for PONG to RFC6455

### DIFF
--- a/src/Ratchet/WebSocket/Version/RFC6455.php
+++ b/src/Ratchet/WebSocket/Version/RFC6455.php
@@ -160,6 +160,9 @@ class RFC6455 implements VersionInterface {
                         $from->send($this->newFrame($frame->getPayload(), true, $frame::OP_PONG));
                     break;
                     case $frame::OP_PONG:
+                        if (method_exists($from->WebSocket->coalescedCallback, 'onPong')) {
+                            $from->WebSocket->coalescedCallback->onPong($from, $frame);
+                        }
                     break;
                     default:
                         return $from->close($frame::CLOSE_PROTOCOL);


### PR DESCRIPTION
This change has onMessage in RFC6455 check to see if the coalescedCallback has an onPong method and will send PONG frames to that handler.

Not sure if this is the cleanest method, but it seemed simple enough.