### PR TITLE
Adds Route support in App->route()

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -119,7 +119,20 @@ class App {
             $decorated = new OriginCheck($decorated, $allowedOrigins);
         }
 
-        $this->routes->add('rr-' . ++$this->_routeCounter, new Route($path, array('_controller' => $decorated), array('Origin' => $this->httpHost), array(), $httpHost));
+        $route = null;
+        if ($path instanceof Route) {
+            $route = $path;
+            $route->setDefault('_controller', $decorated);
+            $route->addRequirements(array('Origin' => $this->httpHost));
+            $route->setHost($httpHost);
+        } else {
+            $route = new Route($path, array(
+                '_controller' => $decorated
+            ), array(
+                'Origin' => $this->httpHost
+            ), array(), $httpHost);
+        }
+        $this->routes->add('rr-' . ++$this->_routeCounter, $route);
 
         return $decorated;
     }


### PR DESCRIPTION
This PR allows to provide a Route object as $path in order to be able to build more complex endpoints, such as:

``` php
$app->route(new Route('/{any}', array(), array('any' => '.*')), $httpServer);
```

(this redirects all URLs to the controller)
