### PR TITLE
Fix conflicting classes

### DIFF
--- a/src/Ratchet/WebSocket/Version/MessageDataInterface.php
+++ b/src/Ratchet/WebSocket/Version/MessageDataInterface.php
@@ -1,10 +1,10 @@
 <?php
 namespace Ratchet\WebSocket\Version;
 
-interface MessageInterface extends DataInterface {
+interface MessageDataInterface extends DataInterface {
     /**
      * @param FrameInterface $fragment
-     * @return MessageInterface
+     * @return MessageDataInterface
      */
     function addFrame(FrameInterface $fragment);
 

--- a/src/Ratchet/WebSocket/Version/RFC6455/Message.php
+++ b/src/Ratchet/WebSocket/Version/RFC6455/Message.php
@@ -1,9 +1,9 @@
 <?php
 namespace Ratchet\WebSocket\Version\RFC6455;
-use Ratchet\WebSocket\Version\MessageInterface;
+use Ratchet\WebSocket\Version\MessageDataInterface;
 use Ratchet\WebSocket\Version\FrameInterface;
 
-class Message implements MessageInterface, \Countable {
+class Message implements MessageDataInterface, \Countable {
     /**
      * @var \SplDoublyLinkedList
      */


### PR DESCRIPTION
Fatal error: Cannot use Ratchet\MessageInterface as MessageInterface because the name is already in use in /Users/sergey/web/crm-dev/vendor/cboden/ratchet/src/Ratchet/
WebSocket/Version/RFC6455.php on line 4
