### PR TITLE
support wildcard hostname for route matching

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -119,7 +119,10 @@ class App {
             $decorated = new OriginCheck($decorated, $allowedOrigins);
         }
 
-        $this->routes->add('rr-' . ++$this->_routeCounter, new Route($path, array('_controller' => $decorated), array('Origin' => $this->httpHost), array(), $httpHost));
+        $routeRequirements = '*' !== $this->httpHost ? array('Origin' => $this->httpHost) : array();
+        $routeHost = '*' !== $httpHost ? $httpHost : null;
+
+        $this->routes->add('rr-' . ++$this->_routeCounter, new Route($path, array('_controller' => $decorated), $routeRequirements, array(), $routeHost));
 
         return $decorated;
     }


### PR DESCRIPTION
to be able to support `new \Ratchet\App('*', 8000, '0.0.0.0', $loop);`
