### PR TITLE
Added two "property" PHPDoc tags

### DIFF
--- a/src/Ratchet/ConnectionInterface.php
+++ b/src/Ratchet/ConnectionInterface.php
@@ -1,5 +1,6 @@
 <?php
 namespace Ratchet;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * The version of Ratchet being used
@@ -10,6 +11,8 @@ const VERSION = 'Ratchet/0.3.2';
 /**
  * A proxy object representing a connection to the application
  * This acts as a container to store data (in memory) about the connection
+ * @property Session $Session
+ * @property int $resourceId
  */
 interface ConnectionInterface {
     /**


### PR DESCRIPTION
I added two [@property](http://www.phpdoc.org/docs/latest/references/phpdoc/tags/property.html) [PHPDoc](http://www.phpdoc.org/) tags to correct two [PhpStorm](https://www.jetbrains.com/phpstorm/) inspection warnings.
### Before

![before](https://cloud.githubusercontent.com/assets/2417752/5025952/f3c7a714-6b1e-11e4-8be7-378f55e643e8.png)
### After

![after](https://cloud.githubusercontent.com/assets/2417752/5025951/f3c70fe8-6b1e-11e4-9801-93491317ab64.png)
