### PR TITLE
Remove unneeded catch

### DIFF
--- a/src/Ratchet/Wamp/WampServer.php
+++ b/src/Ratchet/Wamp/WampServer.php
@@ -41,8 +41,6 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
             $this->wampProtocol->onMessage($conn, $msg);
         } catch (Exception $we) {
             $conn->close(1007);
-        } catch (JsonException $je) {
-            $conn->close(1007);
         }
     }
 


### PR DESCRIPTION
The second JsonException catch in not necessary, and can be removed.