### PR TITLE
Replaced guzzle/http with guzzle/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   , "require": {
         "php": ">=5.3.9"
       , "react/socket": "0.3.*|0.4.*"
-      , "guzzle/http": "~3.6"
+      , "guzzle/guzzle": "~3.9"
       , "symfony/http-foundation": "~2.2"
       , "symfony/routing": "~2.2"
     }


### PR DESCRIPTION
This addresses #285

We were having issues with the old version of Guzzle not parsing the URL path sometimes, when building the `Request`.  Upgrading the version of Guzzle fixed it. https://github.com/voryx/Thruway/issues/85#issuecomment-76984691

