### PR TITLE
Fix the package warnings for guzzle/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   , "require": {
         "php": ">=5.3.9"
       , "react/socket": "0.3.*|0.4.*"
-      , "guzzle/http": "~3.6"
+      , "guzzle/guzzle": "~3.6"
       , "symfony/http-foundation": "~2.2"
       , "symfony/routing": "~2.2"
     }


### PR DESCRIPTION
guzzle/http is abandoned and gives you following warnings when running composer install/update.

`
Package guzzle/common is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/stream is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/parser is abandoned, you should avoid using it. Use guzzle/guzzle instead.
Package guzzle/http is abandoned, you should avoid using it. Use guzzle/guzzle instead.
`

This pull request simply replaces guzzle/http with guzzle/guzzle in the composer.json file.