### PR TITLE
Fix and test for uncommon payload length issue

### DIFF
--- a/src/Ratchet/WebSocket/Version/RFC6455/Frame.php
+++ b/src/Ratchet/WebSocket/Version/RFC6455/Frame.php
@@ -379,6 +379,7 @@ class Frame implements FrameInterface {
 
         $byte_length = $this->getNumPayloadBytes();
         if ($this->bytesRecvd < 1 + $byte_length) {
+            $this->defPayLen = -1;
             throw new \UnderflowException('Not enough data buffered to determine payload length');
         }
 


### PR DESCRIPTION
This addresses a frame boundary issue when the first 3 bytes of a frame with a payload greater than 126 was added to the frame buffer and then Frame::getPayloadLength was called. It would cause the frame to set the payload length to 126 and then not recalculate it once the full length information was available. This is fixed by setting the defPayLen back to -1 before the underflow exception is thrown.