### PR TITLE
Removed special @temporary annotation

### DIFF
--- a/src/Ratchet/WebSocket/WsServerInterface.php
+++ b/src/Ratchet/WebSocket/WsServerInterface.php
@@ -8,7 +8,7 @@ interface WsServerInterface {
     /**
      * If any component in a stack supports a WebSocket sub-protocol return each supported in an array
      * @return array
-     * @temporary This method may be removed in future version (note that will not break code, just make some code obsolete)
+     * @todo This method may be removed in future version (note that will not break code, just make some code obsolete)
      */
     function getSubProtocols();
 }


### PR DESCRIPTION
Removed the use of the special `@temporary` annotation to ease the use of the lib with annotation library, in particular Doctrine annotations

see https://github.com/doctrine/annotations/blob/master/lib/Doctrine/Common/Annotations/AnnotationReader.php#L55 for the list of ignored annotation