### PR TITLE
Added ConnectionInterface::getId

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
       , "guzzle/http": "^3.6"
       , "symfony/http-foundation": "^2.2"
       , "symfony/routing": "^2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/src/Ratchet/AbstractConnectionDecorator.php
+++ b/src/Ratchet/AbstractConnectionDecorator.php
@@ -38,4 +38,11 @@ abstract class AbstractConnectionDecorator implements ConnectionInterface {
     public function __unset($name) {
         unset($this->wrappedConn->$name);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId() {
+        return $this->wrappedConn->getId();
+    }
 }

--- a/src/Ratchet/ConnectionInterface.php
+++ b/src/Ratchet/ConnectionInterface.php
@@ -23,4 +23,10 @@ interface ConnectionInterface {
      * Close the connection
      */
     function close();
+
+    /**
+     * Unique identifier of the connection
+     * @return mixed
+     */
+    function getId();
 }

--- a/src/Ratchet/Server/IoConnection.php
+++ b/src/Ratchet/Server/IoConnection.php
@@ -35,4 +35,12 @@ class IoConnection implements ConnectionInterface {
     public function close() {
         $this->conn->end();
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId()
+    {
+        return (int)$this->conn->stream;
+    }
 }

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -93,7 +93,6 @@ class IoServer {
     public function handleConnect($conn) {
         $conn->decor = new IoConnection($conn);
 
-        $conn->decor->resourceId    = (int)$conn->stream;
         $conn->decor->remoteAddress = $conn->getRemoteAddress();
 
         $this->app->onOpen($conn->decor);

--- a/tests/helpers/Ratchet/Mock/Connection.php
+++ b/tests/helpers/Ratchet/Mock/Connection.php
@@ -17,4 +17,8 @@ class Connection implements ConnectionInterface {
     public function close() {
         $this->last[__FUNCTION__] = true;
     }
+
+    public function getId() {
+        return 0;
+    }
 }

--- a/tests/unit/Server/IoConnectionTest.php
+++ b/tests/unit/Server/IoConnectionTest.php
@@ -29,4 +29,10 @@ class IoConnectionTest extends \PHPUnit_Framework_TestCase {
     public function testSendReturnsSelf() {
         $this->assertSame($this->conn, $this->conn->send('fluent interface'));
     }
+
+    public function testGetId() {
+        $this->sock->stream = "123";
+
+        $this->assertEquals($this->sock->stream, $this->conn->getId());
+    }
 }

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -35,7 +35,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
         $this->server->loop->tick();
 
         //$this->assertTrue(is_string($this->app->last['onOpen'][0]->remoteAddress));
-        //$this->assertTrue(is_int($this->app->last['onOpen'][0]->resourceId));
+        //$this->assertTrue(is_int($this->app->last['onOpen'][0]->getId()));
     }
 
     public function testOnData() {


### PR DESCRIPTION
# Why

It's very useful to retrieve the identifier of the connection, unfortunately the property `$resourceId` is not a part of the `ConnectionInterface`, then we break encapsulation by using it, and there is no type hinting (see https://github.com/ratchetphp/Ratchet/issues/340).
# How

Just added the method in interface, moved the computation logic in `IoConnection` instead of `IoServer`.
# Todo

Same thing for `IoConnection::remoteAddress`...
