### PR TITLE
Fixes VirtualSessionStorage with pdo_sqlite as storage

### DIFF
--- a/src/Ratchet/Session/Storage/VirtualSessionStorage.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorage.php
@@ -30,6 +30,12 @@ class VirtualSessionStorage extends NativeSessionStorage {
             return true;
         }
 
+        // You have to call Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::open() to use
+        // pdo_sqlite (and possible pdo_*) as session storage, if you are using a DSN string instead of a \PDO object
+        // in the constructor. The method arguments are filled with the values, which are also used by the symfony
+        // framework in this case. This must not be the best choice, but it works.
+        $this->saveHandler->open(session_save_path(), session_name());
+
         $rawData     = $this->saveHandler->read($this->saveHandler->getId());
         $sessionData = $this->_serializer->unserialize($rawData);
 

--- a/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
+++ b/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ratchet\Session\Storage;
+
+
+use Ratchet\Session\Serialize\PhpHandler;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
+
+class VirtualSessionStoragePDOTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var VirtualSessionStorage
+     */
+    protected $_virtualSessionStorage;
+
+    protected $_pathToDB;
+
+    public function setUp()
+    {
+        $schema = <<<SQL
+CREATE TABLE `sessions` (
+    `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
+    `sess_data` BLOB NOT NULL,
+    `sess_time` INTEGER UNSIGNED NOT NULL,
+    `sess_lifetime` MEDIUMINT NOT NULL
+);
+SQL;
+        $this->_pathToDB = tempnam(sys_get_temp_dir(), 'SQ3');;
+        $dsn = 'sqlite:' . $this->_pathToDB;
+
+        $pdo = new \PDO($dsn);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec($schema);
+        $pdo = null;
+
+        $sessionHandler = new PdoSessionHandler($dsn);
+        $serializer = new PhpHandler();
+        $this->_virtualSessionStorage = new VirtualSessionStorage($sessionHandler, 'foobar', $serializer);
+        $this->_virtualSessionStorage->registerBag(new FlashBag());
+        $this->_virtualSessionStorage->registerBag(new AttributeBag());
+    }
+
+    public function tearDown()
+    {
+        unlink($this->_pathToDB);
+    }
+
+    public function testStartWithDSN()
+    {
+        $this->_virtualSessionStorage->start();
+
+        $this->assertTrue($this->_virtualSessionStorage->isStarted());
+    }
+
+
+}


### PR DESCRIPTION
Playing with the WebsocketAppDemo, I stumbled over an issue with the VirtualSessionStorage with pdo_sqlite as storage.
It turned out that there was no PDO object in the PDOSessionHandler if the database connection is defined as DSN string. To solve the issue you have to call PdoSessionHandler::open, and since this method is defined in the SessionHandlerInterface it should be save to call it every time (In the MemcacheSessionHandler it always returns true, for example.).

