### PR TITLE
Removed the trigger error while debug is specified

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -60,8 +60,8 @@ class App {
      * @param string        $address  IP address to bind to. Default is localhost/proxy only. '0.0.0.0' for any machine.
      * @param LoopInterface $loop     Specific React\EventLoop to bind the application to. null will create one for you.
      */
-    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null) {
-        if (extension_loaded('xdebug')) {
+    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null, $debug=false) {
+        if (extension_loaded('xdebug') && $debug === false) {
             trigger_error('XDebug extension detected. Remember to disable this if performance testing or going live!', E_USER_WARNING);
         }
 


### PR DESCRIPTION
Hello,

I made this PR that make no BC Break because if I redefine the error management of PHP (sending exception instead of warning), the triggering break everything. (for example in a Symfony Command Context)

The point is to avoid that by adding a new parameter `debug`.
