### PR TITLE
Symfony 3 Composer dependency fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=5.3.9"
       , "react/socket": "^0.3 || ^0.4"
       , "guzzle/http": "^3.6"
-      , "symfony/http-foundation": "^2.2"
+      , "symfony/http-foundation": "^2.2|^3.0"
       , "symfony/routing": "^2.2|^3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
       , "react/socket": "^0.3 || ^0.4"
       , "guzzle/http": "^3.6"
       , "symfony/http-foundation": "^2.2"
-      , "symfony/routing": "^2.2"
+      , "symfony/routing": "^2.2|^3.0"
     }
 }


### PR DESCRIPTION
When using Symfony 3, the dependencies for symfony/http-foundation and symfony/routing in version 2.2 result in a version conflict opposite symfony/symfony 3.0.

This fixes it.