### PR TITLE
0.4 wip/request container

### DIFF
--- a/src/Ratchet/WebSocket/ConnContext.php
+++ b/src/Ratchet/WebSocket/ConnContext.php
@@ -1,0 +1,20 @@
+<?php
+namespace Ratchet\WebSocket;
+use Ratchet\RFC6455\Messaging\MessageBuffer;
+
+class ConnContext {
+    /**
+     * @var \Ratchet\WebSocket\WsConnection
+     */
+    public $connection;
+
+    /**
+     * @var \Ratchet\RFC6455\Messaging\MessageBuffer;
+     */
+    public $streamer;
+
+    public function __construct(WsConnection $conn, MessageBuffer $streamer) {
+        $this->connection = $conn;
+        $this->streamer   = $streamer;
+    }
+}

--- a/src/Ratchet/WebSocket/ConnContext.php
+++ b/src/Ratchet/WebSocket/ConnContext.php
@@ -11,10 +11,10 @@ class ConnContext {
     /**
      * @var \Ratchet\RFC6455\Messaging\MessageBuffer;
      */
-    public $streamer;
+    public $buffer;
 
-    public function __construct(WsConnection $conn, MessageBuffer $streamer) {
+    public function __construct(WsConnection $conn, MessageBuffer $buffer) {
         $this->connection = $conn;
-        $this->streamer   = $streamer;
+        $this->buffer = $buffer;
     }
 }

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -127,8 +127,7 @@ class WsServer implements HttpServerInterface {
             return;
         }
 
-        $context = $this->connections[$from];
-        $context->streamer->onData($msg);
+        $this->connections[$from]->buffer->onData($msg);
     }
 
     /**
@@ -139,7 +138,7 @@ class WsServer implements HttpServerInterface {
             $context = $this->connections[$conn];
             $this->connections->detach($conn);
 
-            $this->delegate->onClose($context->conn);
+            $this->delegate->onClose($context->connection);
         }
     }
 
@@ -148,8 +147,7 @@ class WsServer implements HttpServerInterface {
      */
     public function onError(ConnectionInterface $conn, \Exception $e) {
         if ($this->connections->contains($conn)) {
-            $context = $this->connections[$conn];
-            $this->delegate->onError($context->connection, $e);
+            $this->delegate->onError($this->connections[$from]->connection, $e);
         } else {
             $conn->close();
         }
@@ -194,8 +192,7 @@ class WsServer implements HttpServerInterface {
             $lastPing = new Frame(uniqid(), true, Frame::OP_PING);
 
             foreach ($this->connections as $key => $conn) {
-                $context = $this->connections[$conn];
-                $wsConn  = $context->connection;
+                $wsConn  = $this->connections[$from]->connection;
 
                 $wsConn->send($lastPing);
                 $pingedConnections->attach($wsConn);

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -87,11 +87,10 @@ class WsServer implements HttpServerInterface {
             throw new \UnexpectedValueException('$request can not be null');
         }
 
-        $conn->httpRequest = $request; // This will replace ->WebSocket->request
+        $conn->httpRequest = $request;
 
         $conn->WebSocket            = new \StdClass;
         $conn->WebSocket->closing   = false;
-        $conn->WebSocket->request   = $request; // deprecated
 
         $response = $this->handshakeNegotiator->handshake($request)->withHeader('X-Powered-By', \Ratchet\VERSION);
 


### PR DESCRIPTION
Since we've replaced Guzzle HTTP classes with PSR-7 interfaces we've changed `WebSocket->request` to `->httpRequest` to make the change explicit as well as make the distinction that the HTTP request happened before and is not entirely coupled to the WebSocket.

Also use a specific container for Connection and Buffer instead of indexed array.