### PR TITLE
Session serialize method implementation.

### DIFF
--- a/src/Ratchet/Session/Serialize/PhpHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpHandler.php
@@ -3,10 +3,21 @@ namespace Ratchet\Session\Serialize;
 
 class PhpHandler implements HandlerInterface {
     /**
+     * Simply reverse behaviour of unserialize method.
      * {@inheritdoc}
      */
     function serialize(array $data) {
-        throw new \RuntimeException("Serialize PhpHandler:serialize code not written yet, write me!");
+        $preSerialized = [];
+        $serialized = '';
+        
+        if (count($data)) {
+            foreach ($data as $bucket => $bucketData) {
+                $preSerialized[] = $bucket . '|' . serialize($bucketData);
+            }
+            $serialized = implode('',$preSerialized);
+        }
+        
+        return $serialized;
     }
 
     /**

--- a/src/Ratchet/Session/Serialize/PhpHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpHandler.php
@@ -7,7 +7,7 @@ class PhpHandler implements HandlerInterface {
      * {@inheritdoc}
      */
     function serialize(array $data) {
-        $preSerialized = [];
+        $preSerialized = array();
         $serialized = '';
         
         if (count($data)) {


### PR DESCRIPTION
PhpHandler:serialize: Simply reverse behaviour of 'PhpHandler:unserialize' method.
P.S. Fixed Travis CI issue with PHP 5.3.