### PR TITLE
Fix unsolicited pong crash with keep alive enabled

### DIFF
--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -192,7 +192,7 @@ class WsServer implements HttpServerInterface {
     }
 
     public function enableKeepAlive(LoopInterface $loop, $interval = 30) {
-        $lastPing = null;
+        $lastPing = new Frame(uniqid(), true, Frame::OP_PING);
         $pingedConnections = new \SplObjectStorage;
         $splClearer = new \SplObjectStorage;
 

--- a/tests/autobahn/bin/fuzzingserver.php
+++ b/tests/autobahn/bin/fuzzingserver.php
@@ -23,7 +23,14 @@ class BinaryEcho implements \Ratchet\WebSocket\MessageComponentInterface {
 
     $loop = new $impl;
     $sock = new React\Socket\Server($loop);
-    $app  = new Ratchet\Http\HttpServer(new Ratchet\WebSocket\WsServer(new BinaryEcho));
+
+    $wsServer = new Ratchet\WebSocket\WsServer(new BinaryEcho);
+    // This is enabled to test https://github.com/ratchetphp/Ratchet/issues/430
+    // The time is left at 10 minutes so that it will not try to every ping anything
+    // This causes the Ratchet server to crash on test 2.7
+    $wsServer->enableKeepAlive($loop, 600);
+
+    $app = new Ratchet\Http\HttpServer($wsServer);
 
     $sock->listen($port, '0.0.0.0');
 


### PR DESCRIPTION
Fixes #430.

Autobahn test server now has keep alive enabled to allow for the test to test that part.