### PR TITLE
fix abandoned dependency on guzzle/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   , "require": {
         "php": ">=5.3.9"
       , "react/socket": "^0.3 || ^0.4"
-      , "guzzle/http": "^3.6"
+      , "guzzle/guzzle": "^3.6"
       , "symfony/http-foundation": "^2.2|^3.0"
       , "symfony/routing": "^2.2|^3.0"
     }


### PR DESCRIPTION
Replace abandoned `guzzle/http` dependency with correct `guzzle/guzzle` dependency.