### PR TITLE
Use 403 status code on MethodNotAllowedException.

### DIFF
--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -55,7 +55,7 @@ class Router implements HttpServerInterface {
         }
         $parameters = array_merge($parameters, $request->getQuery()->getAll());
 
-        $url = Url::factory($request->getPath());
+        $url = Url::factory($request->getUrl());
         $url->setQuery($parameters);
         $request->setUrl($url);
 

--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -34,7 +34,7 @@ class Router implements HttpServerInterface {
         try {
             $route = $this->_matcher->match($request->getPath());
         } catch (MethodNotAllowedException $nae) {
-            return $this->close($conn, 405);
+            return $this->close($conn, 405, array('Allow' => $nae->getAllowedMethods()));
         } catch (ResourceNotFoundException $nfe) {
             return $this->close($conn, 404);
         }
@@ -91,13 +91,15 @@ class Router implements HttpServerInterface {
     /**
      * Close a connection with an HTTP response
      * @param \Ratchet\ConnectionInterface $conn
-     * @param int                          $code HTTP status code
+     * @param int $code HTTP status code
+     * @param array $additionalHeaders
      * @return null
      */
-    protected function close(ConnectionInterface $conn, $code = 400) {
-        $response = new Response($code, array(
+    protected function close(ConnectionInterface $conn, $code = 400, array $additionalHeaders = array()) {
+        $headers = array_merge(array(
             'X-Powered-By' => \Ratchet\VERSION
-        ));
+        ), $additionalHeaders);
+        $response = new Response($code, $headers);
 
         $conn->send((string)$response);
         $conn->close();

--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -34,7 +34,7 @@ class Router implements HttpServerInterface {
         try {
             $route = $this->_matcher->match($request->getPath());
         } catch (MethodNotAllowedException $nae) {
-            return $this->close($conn, 403);
+            return $this->close($conn, 405);
         } catch (ResourceNotFoundException $nfe) {
             return $this->close($conn, 404);
         }

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -127,6 +127,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
         );
 
         $conn    = $this->getMock('Ratchet\Mock\Connection');
+        /**@var $request \Guzzle\Http\Message\Request */
         $request = $this->getMock('Guzzle\Http\Message\Request', array('getPath'), array('GET', ''), '', false);
 
         $request->setHeaderFactory($this->getMock('Guzzle\Http\Message\Header\HeaderFactoryInterface'));
@@ -136,5 +137,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
         $router->onOpen($conn, $request);
 
         $this->assertEquals(array('foo' => 'nope', 'baz' => 'qux', 'hello' => 'world'), $request->getQuery()->getAll());
+        $this->assertEquals('ws', $request->getScheme());
+        $this->assertEquals('doesnt.matter', $request->getHost());
     }
 }


### PR DESCRIPTION
According with HTTP RFC (https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6): 
>>> 10.4.6 405 Method Not Allowed 
>>> The method specified in the Request-Line is not allowed for the resource identified by the Request-URI. The response MUST include an Allow header containing a list of valid methods for the requested resource. 

Symfony Route Matcher throw MethodNotAllowedException If the resource was found but the request method is not allowed, but in Ratchet\Http\Router when catch it close connection with 403 code. 