### PR TITLE
Makes X-Powered-By header environment variable

### DIFF
--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -110,7 +110,8 @@ class WsServer implements HttpServerInterface {
         $conn->WebSocket            = new \StdClass;
         $conn->WebSocket->closing   = false;
 
-        $response = $this->handshakeNegotiator->handshake($request)->withHeader('X-Powered-By', \Ratchet\VERSION);
+        $wsServerPoweredBy = strlen(getenv('WS_SERVER_POWERED_BY')) ? getenv('WS_SERVER_POWERED_BY') : \Ratchet\VERSION;
+        $response = $this->handshakeNegotiator->handshake($request)->withHeader('X-Powered-By', $wsServerPoweredBy);
 
         $conn->send(gPsr\str($response));
 


### PR DESCRIPTION
Since it is considered a bad security practice to expose web server technology (and especially versions thereof) to clients, it would be convenient if this header could be changed based on an environment variable.