### PR TITLE
Allow xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can find more details in the [server conf docs](http://socketo.me/docs/deplo
 
 PHP 5.3.9 (or higher) is required. If you have access, PHP 5.4 (or higher) is *highly* recommended for its performance improvements.
 
+If you have XDebug extension enabled, remember to disable it for performance testing or going live!
+
 ### Documentation
 
 User and API documentation is available on Ratchet's website: http://socketo.me

--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -61,10 +61,6 @@ class App {
      * @param LoopInterface $loop     Specific React\EventLoop to bind the application to. null will create one for you.
      */
     public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null) {
-        if (extension_loaded('xdebug')) {
-            trigger_error('XDebug extension detected. Remember to disable this if performance testing or going live!', E_USER_WARNING);
-        }
-
         if (3 !== strlen('✓')) {
             throw new \DomainException('Bad encoding, length of unicode character ✓ should be 3. Ensure charset UTF-8 and check ini val mbstring.func_autoload');
         }


### PR DESCRIPTION
I think I should be allowed to use xdebug. The notice about it's performance belongs to Readme.

Otherwise, the app crashes on error about enabled xdebug and it's impossible to use this library.