### PR TITLE
Handle invalid topics from clients

### DIFF
--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -93,7 +93,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
             throw new Exception("Invalid WAMP message format");
         }
 
-        if (isset($json[1]) && !is_string($json[1])) {
+        if (isset($json[1]) && !(is_string($json[1]) || is_numeric($json[1]))) {
             throw new Exception('Invalid Topic, must be a string');
         }
 

--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -62,9 +62,9 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
             $subs[] = 'wamp';
 
             return $subs;
-        } else {
-            return array('wamp');
         }
+
+        return ['wamp'];
     }
 
     /**
@@ -91,6 +91,10 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
 
         if (!is_array($json) || $json !== array_values($json)) {
             throw new Exception("Invalid WAMP message format");
+        }
+
+        if (isset($json[1]) && !is_string($json[1])) {
+            $json[1] = json_encode($json[1]);
         }
 
         switch ($json[0]) {
@@ -122,13 +126,13 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
                 $exclude  = (array_key_exists(3, $json) ? $json[3] : null);
                 if (!is_array($exclude)) {
                     if (true === (boolean)$exclude) {
-                        $exclude = array($from->WAMP->sessionId);
+                        $exclude = [$from->WAMP->sessionId];
                     } else {
-                        $exclude = array();
+                        $exclude = [];
                     }
                 }
 
-                $eligible = (array_key_exists(4, $json) ? $json[4] : array());
+                $eligible = (array_key_exists(4, $json) ? $json[4] : []);
 
                 $this->_decorating->onPublish($from, $from->getUri($json[1]), $json[2], $exclude, $eligible);
             break;

--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -94,7 +94,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
         }
 
         if (isset($json[1]) && !is_string($json[1])) {
-            $json[1] = json_encode($json[1]);
+            throw new Exception('Invalid Topic, must be a string');
         }
 
         switch ($json[0]) {

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -4,9 +4,9 @@ use Ratchet\Mock\Connection;
 use Ratchet\Mock\WampComponent as TestComponent;
 
 /**
- * @covers Ratchet\Wamp\ServerProtocol
- * @covers Ratchet\Wamp\WampServerInterface
- * @covers Ratchet\Wamp\WampConnection
+ * @covers \Ratchet\Wamp\ServerProtocol
+ * @covers \Ratchet\Wamp\WampServerInterface
+ * @covers \Ratchet\Wamp\WampConnection
  */
 class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     protected $_comp;
@@ -23,13 +23,13 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function invalidMessageProvider() {
-        return array(
-            array(0)
-          , array(3)
-          , array(4)
-          , array(8)
-          , array(9)
-        );
+        return [
+            [0]
+          , [3]
+          , [4]
+          , [8]
+          , [9]
+        ];
     }
 
     /**
@@ -40,7 +40,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
 
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
-        $this->_comp->onMessage($conn, json_encode(array($type)));
+        $this->_comp->onMessage($conn, json_encode([$type]));
     }
 
     public function testWelcomeMessage() {
@@ -82,16 +82,16 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function callProvider() {
-        return array(
-            array(2, 'a', 'b')
-          , array(2, array('a', 'b'))
-          , array(1, 'one')
-          , array(3, 'one', 'two', 'three')
-          , array(3, array('un', 'deux', 'trois'))
-          , array(2, 'hi', array('hello', 'world'))
-          , array(2, array('hello', 'world'), 'hi')
-          , array(2, array('hello' => 'world', 'herp' => 'derp'))
-        );
+        return [
+            [2, 'a', 'b']
+          , [2, ['a', 'b']]
+          , [1, 'one']
+          , [3, 'one', 'two', 'three']
+          , [3, ['un', 'deux', 'trois']]
+          , [2, 'hi', ['hello', 'world']]
+          , [2, ['hello', 'world'], 'hi']
+          , [2, ['hello' => 'world', 'herp' => 'derp']]
+        ];
     }
 
     /**
@@ -102,7 +102,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
         $paramNum = array_shift($args);
 
         $uri = 'http://example.com/endpoint/' . rand(1, 100);
-        $id  = uniqid();
+        $id  = uniqid('', false);
         $clientMessage = array_merge(array(2, $id, $uri), $args);
 
         $conn = $this->newConn();
@@ -145,8 +145,8 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     public function testPublishAndEligible() {
         $conn = $this->newConn();
 
-        $buddy  = uniqid();
-        $friend = uniqid();
+        $buddy  = uniqid('', false);
+        $friend = uniqid('', false);
 
         $this->_comp->onOpen($conn);
         $this->_comp->onMessage($conn, json_encode(array(7, 'topic', 'event', false, array($buddy, $friend))));
@@ -264,5 +264,24 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
         $this->_comp->onMessage($conn, $message);
+    }
+
+    public function testBadClientInputFromNonStringTopic() {
+        $conn = new WampConnection($this->newConn());
+        $this->_comp->onOpen($conn);
+
+        $this->_comp->onMessage($conn, json_encode([5, ['hells', 'nope']]));
+
+        $this->assertEquals('["hells","nope"]', $this->_app->last['onSubscribe'][1]);
+    }
+
+    public function testBadPrefixWithNonStringTopic() {
+        $conn = new WampConnection($this->newConn());
+        $this->_comp->onOpen($conn);
+
+        $this->_comp->onMessage($conn, json_encode([1, ['hells', 'nope'], ['bad', 'input']]));
+        $this->_comp->onMessage($conn, json_encode([7, ['bad', 'input'], 'Hider']));
+
+        $this->assertEquals('["bad","input"]', $this->_app->last['onPublish'][1]);
     }
 }

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -267,21 +267,29 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadClientInputFromNonStringTopic() {
+        $this->setExpectedException('\Ratchet\Wamp\Exception');
+
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
 
         $this->_comp->onMessage($conn, json_encode([5, ['hells', 'nope']]));
-
-        $this->assertEquals('["hells","nope"]', $this->_app->last['onSubscribe'][1]);
     }
 
     public function testBadPrefixWithNonStringTopic() {
+        $this->setExpectedException('\Ratchet\Wamp\Exception');
+
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
 
         $this->_comp->onMessage($conn, json_encode([1, ['hells', 'nope'], ['bad', 'input']]));
-        $this->_comp->onMessage($conn, json_encode([7, ['bad', 'input'], 'Hider']));
+    }
 
-        $this->assertEquals('["bad","input"]', $this->_app->last['onPublish'][1]);
+    public function testBadPublishWithNonStringTopic() {
+        $this->setExpectedException('\Ratchet\Wamp\Exception');
+
+        $conn = new WampConnection($this->newConn());
+        $this->_comp->onOpen($conn);
+
+        $this->_comp->onMessage($conn, json_encode([7, ['bad', 'input'], 'Hider']));
     }
 }


### PR DESCRIPTION
The client is supposed to send a string as a topic but we're going to re-json'ify the topic in case of bad client input.

fixes #516 