### PR TITLE
Added context to App facade constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cboden/ratchet"
+    "name": "minifets/ratchet"
   , "type": "library"
   , "description": "PHP WebSocket library"
   , "keywords": ["WebSockets", "Server", "Ratchet", "Sockets", "WebSocket"]

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "minifets/ratchet"
+    "name": "cboden/ratchet"
   , "type": "library"
   , "description": "PHP WebSocket library"
   , "keywords": ["WebSockets", "Server", "Ratchet", "Sockets", "WebSocket"]

--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -60,8 +60,9 @@ class App {
      * @param int           $port       Port to listen on. If 80, assuming production, Flash on 843 otherwise expecting Flash to be proxied through 8843
      * @param string        $address    IP address to bind to. Default is localhost/proxy only. '0.0.0.0' for any machine.
      * @param LoopInterface $loop       Specific React\EventLoop to bind the application to. null will create one for you.
+     * @param array         $context
      */
-    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null) {
+    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null, $context = array()) {
         if (extension_loaded('xdebug')) {
             trigger_error('XDebug extension detected. Remember to disable this if performance testing or going live!', E_USER_WARNING);
         }
@@ -73,7 +74,7 @@ class App {
         $this->httpHost = $httpHost;
         $this->port = $port;
 
-        $socket = new Reactor($address . ':' . $port, $loop);
+        $socket = new Reactor($address . ':' . $port, $loop, $context);
 
         $this->routes  = new RouteCollection;
         $this->_server = new IoServer(new HttpServer(new Router(new UrlMatcher($this->routes, new RequestContext))), $socket, $loop);


### PR DESCRIPTION
This will help to create the tls server.

For example:
`
$app = new App('localhost', 8080, 'tls://0.0.0.0', $loop, ['tls' => [
    'allow_self_signed' => true,
    'local_cert' => '/etc/nginx/ssl/localhost.crt',
    'local_pk' => '/etc/nginx/ssl/localhost.key'
]]);`