### PR TITLE
Add route defaults support

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -97,9 +97,10 @@ class App {
      * @param ComponentInterface $controller Your application to server for the route. If not specified, assumed to be for a WebSocket
      * @param array              $allowedOrigins An array of hosts allowed to connect (same host by default), ['*'] for any
      * @param string             $httpHost Override the $httpHost variable provided in the __construct
+     * @param array              $defaulValues An array of default parameter values passed to symfony route config
      * @return ComponentInterface|WsServer
      */
-    public function route($path, ComponentInterface $controller, array $allowedOrigins = array(), $httpHost = null) {
+    public function route($path, ComponentInterface $controller, array $allowedOrigins = array(), $httpHost = null,$defaulValues=array()) {
         if ($controller instanceof HttpServerInterface || $controller instanceof WsServer) {
             $decorated = $controller;
         } elseif ($controller instanceof WampServerInterface) {
@@ -131,7 +132,9 @@ class App {
             }
         }
 
-        $this->routes->add('rr-' . ++$this->_routeCounter, new Route($path, array('_controller' => $decorated), array('Origin' => $this->httpHost), array(), $httpHost, array(), array('GET')));
+        $defaulValues['_controller'] = $decorated;
+
+        $this->routes->add('rr-' . ++$this->_routeCounter, new Route($path, $defaulValues, array('Origin' => $this->httpHost), array(), $httpHost, array(), array('GET')));
 
         return $decorated;
     }


### PR DESCRIPTION
Feature: Add support for default values in Symfony route configuration

With the current version of Ratchet, it is possible to make wildcard routes using route placeholders as mentioned in  [Symfony routing docs](https://symfony.com/doc/current/routing.html)

I have written more about this here: [How to implement wildcard routes in Ratchet WebSocket server](https://hack4m.com/how-to-implement-wildcard-routes-in-ratchet-websocket-server/)

 
However, there is a catch.
We can use routing placeholders but cannot make any of them optional, by passing a default value for them.

What this merge will add:
- Add an optional 5th parameter to \Ratchet\App::route that is passed to \Symfony\Component\Routing\RouteCollection::add along with the _controller option.


For a setup like this:
`$server->route('/{something}/{anotherThing}',  new MyApp(), array('*'))`

After the merge, we can make `anotherThing` optional by modifying the route config to this:

`$server->route('/{something}/{anotherThing}',  new MyApp(), array('*'),null,array('anotherThing'=>1))`

