### PR TITLE
Introduced IdentifiedConnectionInterface for usage in IoServer

### DIFF
--- a/src/Ratchet/IdentifiedConnectionInterface.php
+++ b/src/Ratchet/IdentifiedConnectionInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace Ratchet;
+
+/**
+ * A proxy object representing a connection which can be identified by an id.
+ */
+interface IdentifiedConnectionInterface extends ConnectionInterface {
+
+    /**
+     * Unique identifier of a connection
+     * @return mixed
+     */
+    function getId();
+}

--- a/src/Ratchet/Server/IoConnection.php
+++ b/src/Ratchet/Server/IoConnection.php
@@ -1,23 +1,30 @@
 <?php
 namespace Ratchet\Server;
 use Ratchet\ConnectionInterface;
+use Ratchet\IdentifiedConnectionInterface;
 use React\Socket\ConnectionInterface as ReactConn;
 
 /**
  * {@inheritdoc}
  */
-class IoConnection implements ConnectionInterface {
+class IoConnection implements IdentifiedConnectionInterface {
     /**
      * @var \React\Socket\ConnectionInterface
      */
     protected $conn;
 
+    /**
+     * @var int
+     */
+    private $id;
 
     /**
      * @param \React\Socket\ConnectionInterface $conn
+     * @param int the connection identifier
      */
-    public function __construct(ReactConn $conn) {
+    public function __construct(ReactConn $conn, $id) {
         $this->conn = $conn;
+        $this->id = $id;
     }
 
     /**
@@ -34,5 +41,12 @@ class IoConnection implements ConnectionInterface {
      */
     public function close() {
         $this->conn->end();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getId() {
+        return $this->id;
     }
 }

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -80,8 +80,7 @@ class IoServer {
      * @param \React\Socket\ConnectionInterface $conn
      */
     public function handleConnect($conn) {
-        $conn->decor = new IoConnection($conn);
-        $conn->decor->resourceId = (int)$conn->stream;
+        $conn->decor = new IoConnection($conn, (int)$conn->stream);
 
         $uri = $conn->getRemoteAddress();
         $conn->decor->remoteAddress = trim(

--- a/tests/unit/Server/IoConnectionTest.php
+++ b/tests/unit/Server/IoConnectionTest.php
@@ -11,7 +11,7 @@ class IoConnectionTest extends \PHPUnit_Framework_TestCase {
 
     public function setUp() {
         $this->sock = $this->getMock('\\React\\Socket\\ConnectionInterface');
-        $this->conn = new IoConnection($this->sock);
+        $this->conn = new IoConnection($this->sock, 123);
     }
 
     public function testCloseBubbles() {
@@ -28,5 +28,9 @@ class IoConnectionTest extends \PHPUnit_Framework_TestCase {
 
     public function testSendReturnsSelf() {
         $this->assertSame($this->conn, $this->conn->send('fluent interface'));
+    }
+
+    public function testGetId() {
+        $this->assertEquals(123, $this->conn->getId());
     }
 }

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -44,7 +44,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
         $this->tickLoop($this->server->loop);
 
         //$this->assertTrue(is_string($this->app->last['onOpen'][0]->remoteAddress));
-        //$this->assertTrue(is_int($this->app->last['onOpen'][0]->resourceId));
+        //$this->assertTrue(is_int($this->app->last['onOpen'][0]->getId()));
     }
 
     public function testOnData() {


### PR DESCRIPTION
> Added new class IdentifiedConnectionInterface
> Capsuled $resourceId in seperate method getId of new class.
> Extended unit tests.

While developing a chat application and trying to learn from your tutorial I discovered an issue at the public property "resourceId" on a given ConnectionInterface-object which is used to recognize clients server side.

The `$resourceId` was set in `Ratchet\Server\IoServer` (line 84). Since it is written to a Connection without initializing it first, it is automatically initialized public. This is well known as being dangerous for API methods and should be avoided in PHP.
In my opinion it should be accessible (for read) via an public API method and set within the Constructor. Otherwise no one can guarantee for this property being still there in future releases.
This is why I capsuled this property in an separate interface.
Feel free to optimize my solution.

Thanks for your work on this excellent WS-library for PHP!
It would nice to help you with my contribution :)

Greetings
Tim