### PR TITLE
Use Throwable instead of Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 * 0.5.0
   * PHP 7.2 is minimum supported version
   * BC: `Ratchet\Session\Storage\Proxy\VirtualSessionStorage` requires `Ratchet\Session\OptionsHandler`
+  * `ComponentInterface::onError()` now accepts `Throwable` instead of `Exception`
 
 * 0.4.1 (2017-12-11)
   * Only enableKeepAlive in App if no WsServer passed allowing user to set their own timeout duration

--- a/src/Ratchet/ComponentInterface.php
+++ b/src/Ratchet/ComponentInterface.php
@@ -1,6 +1,8 @@
 <?php
 namespace Ratchet;
 
+use Throwable;
+
 /**
  * This is the interface to build a Ratchet application with.
  * It implements the decorator pattern to build an application stack
@@ -9,23 +11,23 @@ interface ComponentInterface {
     /**
      * When a new connection is opened it will be passed to this method
      * @param  ConnectionInterface $conn The socket/connection that just connected to your application
-     * @throws \Exception
+     * @throws Throwable
      */
     function onOpen(ConnectionInterface $conn);
 
     /**
      * This is called before or after a socket is closed (depends on how it's closed).  SendMessage to $conn will not result in an error if it has already been closed.
      * @param  ConnectionInterface $conn The socket/connection that is closing/closed
-     * @throws \Exception
+     * @throws Throwable
      */
     function onClose(ConnectionInterface $conn);
 
     /**
-     * If there is an error with one of the sockets, or somewhere in the application where an Exception is thrown,
-     * the Exception is sent back down the stack, handled by the Server and bubbled back up the application through this method
+     * If there is an error with one of the sockets, or somewhere in the application where an Throwable is thrown,
+     * the Throwable is sent back down the stack, handled by the Server and bubbled back up the application through this method
      * @param  ConnectionInterface $conn
-     * @param  \Exception          $e
-     * @throws \Exception
+     * @param  Throwable          $e
+     * @throws Throwable
      */
-    function onError(ConnectionInterface $conn, \Exception $e);
+    function onError(ConnectionInterface $conn, Throwable $e);
 }

--- a/src/Ratchet/Http/HttpServer.php
+++ b/src/Ratchet/Http/HttpServer.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Http;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 class HttpServer implements MessageComponentInterface {
     use CloseResponseTrait;
@@ -66,7 +67,7 @@ class HttpServer implements MessageComponentInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         if ($conn->httpHeadersReceived) {
             $this->_httpServer->onError($conn, $e);
         } else {

--- a/src/Ratchet/Http/NoOpHttpServerController.php
+++ b/src/Ratchet/Http/NoOpHttpServerController.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Http;
 use Ratchet\ConnectionInterface;
 use Psr\Http\Message\RequestInterface;
+use Throwable;
 
 class NoOpHttpServerController implements HttpServerInterface {
     public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
@@ -13,6 +14,6 @@ class NoOpHttpServerController implements HttpServerInterface {
     public function onClose(ConnectionInterface $conn) {
     }
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
     }
 }

--- a/src/Ratchet/Http/OriginCheck.php
+++ b/src/Ratchet/Http/OriginCheck.php
@@ -3,6 +3,7 @@ namespace Ratchet\Http;
 use Ratchet\ConnectionInterface;
 use Ratchet\MessageComponentInterface;
 use Psr\Http\Message\RequestInterface;
+use Throwable;
 
 /**
  * A middleware to ensure JavaScript clients connecting are from the expected domain.
@@ -59,7 +60,7 @@ class OriginCheck implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    function onError(ConnectionInterface $conn, \Exception $e) {
+    function onError(ConnectionInterface $conn, Throwable $e) {
         return $this->_component->onError($conn, $e);
     }
 }

--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -6,6 +6,7 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use GuzzleHttp\Psr7 as gPsr;
+use Throwable;
 
 class Router implements HttpServerInterface {
     use CloseResponseTrait;
@@ -88,7 +89,7 @@ class Router implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         if (isset($conn->controller)) {
             $conn->controller->onError($conn, $e);
         }

--- a/src/Ratchet/MessageInterface.php
+++ b/src/Ratchet/MessageInterface.php
@@ -1,12 +1,14 @@
 <?php
 namespace Ratchet;
 
+use Throwable;
+
 interface MessageInterface {
     /**
      * Triggered when a client sends data through the socket
      * @param  \Ratchet\ConnectionInterface $from The socket/connection that sent the message to your application
      * @param  string                       $msg  The message received
-     * @throws \Exception
+     * @throws Throwable
      */
     function onMessage(ConnectionInterface $from, $msg);
 }

--- a/src/Ratchet/Server/EchoServer.php
+++ b/src/Ratchet/Server/EchoServer.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Server;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 /**
  * A simple Ratchet application that will reply to all messages with the message it received
@@ -17,7 +18,7 @@ class EchoServer implements MessageComponentInterface {
     public function onClose(ConnectionInterface $conn) {
     }
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $conn->close();
     }
 }

--- a/src/Ratchet/Server/FlashPolicy.php
+++ b/src/Ratchet/Server/FlashPolicy.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Server;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 /**
  * An app to go on a server stack to pass a policy file to a Flash socket
@@ -132,7 +133,7 @@ class FlashPolicy implements MessageComponentInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $conn->close();
     }
 

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -6,6 +6,7 @@ use React\Socket\ServerInterface;
 use React\EventLoop\Factory as LoopFactory;
 use React\Socket\Server as Reactor;
 use React\Socket\SecureServer as SecureReactor;
+use Throwable;
 
 /**
  * Creates an open-ended socket to listen on a port for incoming connections.
@@ -97,7 +98,7 @@ class IoServer {
         $conn->on('close', function () use ($conn) {
             $this->handleEnd($conn);
         });
-        $conn->on('error', function (\Exception $e) use ($conn) {
+        $conn->on('error', function (Throwable $e) use ($conn) {
             $this->handleError($e, $conn);
         });
     }
@@ -110,7 +111,7 @@ class IoServer {
     public function handleData($data, $conn) {
         try {
             $this->app->onMessage($conn->decor, $data);
-        } catch (\Exception $e) {
+        } catch (Throwable $e) {
             $this->handleError($e, $conn);
         }
     }
@@ -122,7 +123,7 @@ class IoServer {
     public function handleEnd($conn) {
         try {
             $this->app->onClose($conn->decor);
-        } catch (\Exception $e) {
+        } catch (Throwable $e) {
             $this->handleError($e, $conn);
         }
 
@@ -131,10 +132,10 @@ class IoServer {
 
     /**
      * An error has occurred, let the listening application know
-     * @param \Exception                        $e
+     * @param Throwable                         $e
      * @param \React\Socket\ConnectionInterface $conn
      */
-    public function handleError(\Exception $e, $conn) {
+    public function handleError(Throwable $e, $conn) {
         $this->app->onError($conn->decor, $e);
     }
 }

--- a/src/Ratchet/Server/IpBlackList.php
+++ b/src/Ratchet/Server/IpBlackList.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Server;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 class IpBlackList implements MessageComponentInterface {
     /**
@@ -67,7 +68,7 @@ class IpBlackList implements MessageComponentInterface {
      */
     public function filterAddress($address) {
         if (strstr($address, ':') && substr_count($address, '.') == 3) {
-            list($address, $port) = explode(':', $address);
+            [$address, $port] = explode(':', $address);
         }
 
         return $address;
@@ -103,7 +104,7 @@ class IpBlackList implements MessageComponentInterface {
     /**
      * {@inheritdoc}
      */
-    function onError(ConnectionInterface $conn, \Exception $e) {
+    function onError(ConnectionInterface $conn, Throwable $e) {
         if (!$this->isBlocked($conn->remoteAddress)) {
             $this->_decorating->onError($conn, $e);
         }

--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -9,6 +9,7 @@ use Ratchet\Session\Storage\VirtualSessionStorage;
 use Ratchet\Session\Serialize\HandlerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Throwable;
 
 /**
  * This component will allow access to session data from your website for each user connected
@@ -125,7 +126,7 @@ class SessionProvider implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    function onError(ConnectionInterface $conn, \Exception $e) {
+    function onError(ConnectionInterface $conn, Throwable $e) {
         return $this->_app->onError($conn, $e);
     }
 

--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -3,6 +3,7 @@ namespace Ratchet\Wamp;
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 /**
  * WebSocket Application Messaging Protocol
@@ -155,7 +156,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         return $this->_decorating->onError($this->connections[$conn], $e);
     }
 }

--- a/src/Ratchet/Wamp/TopicManager.php
+++ b/src/Ratchet/Wamp/TopicManager.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Wamp;
 use Ratchet\ConnectionInterface;
 use Ratchet\WebSocket\WsServerInterface;
+use Throwable;
 
 class TopicManager implements WsServerInterface, WampServerInterface {
     /**
@@ -84,7 +85,7 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $this->app->onError($conn, $e);
     }
 

--- a/src/Ratchet/Wamp/WampServer.php
+++ b/src/Ratchet/Wamp/WampServer.php
@@ -3,6 +3,7 @@ namespace Ratchet\Wamp;
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 /**
  * Enable support for the official WAMP sub-protocol in your application
@@ -39,7 +40,7 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
     public function onMessage(ConnectionInterface $conn, $msg) {
         try {
             $this->wampProtocol->onMessage($conn, $msg);
-        } catch (Exception $we) {
+        } catch (Throwable $we) {
             $conn->close(1007);
         }
     }
@@ -54,7 +55,7 @@ class WampServer implements MessageComponentInterface, WsServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $this->wampProtocol->onError($conn, $e);
     }
 

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -15,6 +15,7 @@ use Ratchet\RFC6455\Handshake\ServerNegotiator;
 use Ratchet\RFC6455\Handshake\RequestVerifier;
 use React\EventLoop\LoopInterface;
 use GuzzleHttp\Psr7 as gPsr;
+use Throwable;
 
 /**
  * The adapter to handle WebSocket requests/responses
@@ -168,7 +169,7 @@ class WsServer implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         if ($this->connections->contains($conn)) {
             $this->delegate->onError($this->connections[$conn]->connection, $e);
         } else {

--- a/tests/autobahn/bin/fuzzingserver.php
+++ b/tests/autobahn/bin/fuzzingserver.php
@@ -14,7 +14,7 @@ class BinaryEcho implements \Ratchet\WebSocket\MessageComponentInterface {
     public function onClose(ConnectionInterface $conn) {
     }
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
     }
 }
 

--- a/tests/helpers/Ratchet/Mock/Component.php
+++ b/tests/helpers/Ratchet/Mock/Component.php
@@ -3,6 +3,7 @@ namespace Ratchet\Mock;
 use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 class Component implements MessageComponentInterface, WsServerInterface {
     public $last = array();
@@ -25,7 +26,7 @@ class Component implements MessageComponentInterface, WsServerInterface {
         $this->last[__FUNCTION__] = func_get_args();
     }
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $this->last[__FUNCTION__] = func_get_args();
     }
 

--- a/tests/helpers/Ratchet/Mock/WampComponent.php
+++ b/tests/helpers/Ratchet/Mock/WampComponent.php
@@ -3,6 +3,7 @@ namespace Ratchet\Mock;
 use Ratchet\Wamp\WampServerInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use Ratchet\ConnectionInterface;
+use Throwable;
 
 class WampComponent implements WampServerInterface, WsServerInterface {
     public $last = array();
@@ -37,7 +38,7 @@ class WampComponent implements WampServerInterface, WsServerInterface {
         $this->last[__FUNCTION__] = func_get_args();
     }
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {
+    public function onError(ConnectionInterface $conn, Throwable $e) {
         $this->last[__FUNCTION__] = func_get_args();
     }
 }

--- a/tests/helpers/Ratchet/NullComponent.php
+++ b/tests/helpers/Ratchet/NullComponent.php
@@ -1,9 +1,8 @@
 <?php
 namespace Ratchet;
-use Ratchet\ConnectionInterface;
-use Ratchet\MessageComponentInterface;
 use Ratchet\WebSocket\WsServerInterface;
 use Ratchet\Wamp\WampServerInterface;
+use Throwable;
 
 class NullComponent implements MessageComponentInterface, WsServerInterface, WampServerInterface {
     public function onOpen(ConnectionInterface $conn) {}
@@ -12,7 +11,7 @@ class NullComponent implements MessageComponentInterface, WsServerInterface, Wam
 
     public function onClose(ConnectionInterface $conn) {}
 
-    public function onError(ConnectionInterface $conn, \Exception $e) {}
+    public function onError(ConnectionInterface $conn, Throwable $e) {}
 
     public function onCall(ConnectionInterface $conn, $id, $topic, array $params) {}
 


### PR DESCRIPTION
In PHP 7.0, a Throwable interface was added that allows catching and handling errors in more cases than Exception previously allowed. So, if the catch statement contained Exception on PHP 5.x, it means it should probably be rewritten to reference Throwable on PHP 7.x.

_Contains commit from #773_