### PR TITLE
MessageComponentInterface without prior use statement

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -11,6 +11,7 @@ use Ratchet\Server\IoServer;
 use Ratchet\Server\FlashPolicy;
 use Ratchet\Http\HttpServer;
 use Ratchet\Http\Router;
+use Ratchet\WebSocket\MessageComponentInterface as DataComponentInterface;
 use Ratchet\WebSocket\WsServer;
 use Ratchet\Wamp\WampServer;
 use Symfony\Component\Routing\RouteCollection;
@@ -105,7 +106,7 @@ class App {
         } elseif ($controller instanceof WampServerInterface) {
             $decorated = new WsServer(new WampServer($controller));
             $decorated->enableKeepAlive($this->_server->loop);
-        } elseif ($controller instanceof MessageComponentInterface) {
+        } elseif ($controller instanceof MessageComponentInterface || $controller instanceof DataComponentInterface) {
             $decorated = new WsServer($controller);
             $decorated->enableKeepAlive($this->_server->loop);
         } else {


### PR DESCRIPTION
There is silent error in App->route() about using controller that implements MessageComponentInterface