### PR TITLE
Add option to measure client latency 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     }
   , "require": {
-      , "ratchet/rfc6455": "^0.3"
+      "ratchet/rfc6455": "^0.3"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "guzzlehttp/psr7": "^1.0"
       , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     }
   , "require": {
         "php": "^7.2"
-      , "ratchet/rfc6455": "^0.2"
+      , "ratchet/rfc6455": "^0.3"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "guzzlehttp/psr7": "^1.0"
       , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         }
     }
   , "require": {
-        "php": "^7.2"
       , "ratchet/rfc6455": "^0.3"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "guzzlehttp/psr7": "^1.0"

--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -46,24 +46,20 @@ class SessionProvider implements HttpServerInterface {
      * @param array<string, mixed> $options
      * @throws \RuntimeException
      */
-    public function __construct(HttpServerInterface $app, \SessionHandlerInterface $handler, array $options = array(), HandlerInterface $serializer = null, ?OptionsHandlerInterface $optionsHandler = null) {
+    public function __construct(HttpServerInterface $app, \SessionHandlerInterface $handler, array $options = array(), ?HandlerInterface $serializer = null, ?OptionsHandlerInterface $optionsHandler = null) {
         $this->_app           = $app;
         $this->_handler       = $handler;
         $this->_null          = new NullSessionHandler;
-        $this->optionsHandler = $optionsHandler;
+        $this->optionsHandler = $optionsHandler ?? new IniOptionsHandler();
 
-        if($optionsHandler === null){
-            $optionsHandler = new IniOptionsHandler();
-        }
-
-        $optionsHandler->set('session.auto_start', 0);
-        $optionsHandler->set('session.cache_limiter', '');
-        $optionsHandler->set('session.use_cookies', 0);
+        $this->optionsHandler->set('session.auto_start', 0);
+        $this->optionsHandler->set('session.cache_limiter', '');
+        $this->optionsHandler->set('session.use_cookies', 0);
 
         $this->setOptions($options);
 
         if (null === $serializer) {
-            $serialClass = __NAMESPACE__ . "\\Serialize\\{$this->toClassCase($optionsHandler->get('session.serialize_handler'))}Handler"; // awesome/terrible hack, eh?
+            $serialClass = __NAMESPACE__ . "\\Serialize\\{$this->toClassCase($this->optionsHandler->get('session.serialize_handler'))}Handler"; // awesome/terrible hack, eh?
             if (!class_exists($serialClass)) {
                 throw new \RuntimeException('Unable to parse session serialize handler');
             }

--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -114,7 +114,7 @@ class SessionProvider implements HttpServerInterface {
      */
     function onClose(ConnectionInterface $conn) {
         // "close" session for Connection
-
+        $this->_handler->close();
         return $this->_app->onClose($conn);
     }
 

--- a/src/Ratchet/WebSocket/WsConnection.php
+++ b/src/Ratchet/WebSocket/WsConnection.php
@@ -10,6 +10,21 @@ use Ratchet\RFC6455\Messaging\Frame;
  */
 class WsConnection extends AbstractConnectionDecorator {
     /**
+     * @var int
+     */
+    public $pingSendTime = 0;
+
+    /**
+     * @var sting
+     */
+    public $lastPingPayload = '';
+
+    /**
+     * @var float
+     */
+    public $latency = NAN;
+
+    /**
      * {@inheritdoc}
      */
     public function send($msg) {


### PR DESCRIPTION
This (very crude) initial implementation adds the method enableLatencyMeasuring() to the WsServer class. 
It is similar to the enableKeepAlive() method and will also keep the connections alive by pining the clients repeatedly. 
But it also keeps track of the ping times and can therefore provide a latency value (in milliseconds) for each connection.
The latency can be read like any other connection property.
