### PR TITLE
Set default options handler before assigning class var

### DIFF
--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -51,11 +51,12 @@ class SessionProvider implements HttpServerInterface {
         $this->_app           = $app;
         $this->_handler       = $handler;
         $this->_null          = new NullSessionHandler;
-        $this->optionsHandler = $optionsHandler;
 
         if($optionsHandler === null){
             $optionsHandler = new IniOptionsHandler();
         }
+
+        $this->optionsHandler = $optionsHandler;
 
         $optionsHandler->set('session.auto_start', 0);
         $optionsHandler->set('session.cache_limiter', '');


### PR DESCRIPTION
Without this change, `$this->optionsHandler` never gets the default `IniOptionsHandler` set.