### PR TITLE
changes for use in AuthWsServerWrapper.onError

### DIFF
--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -29,7 +29,7 @@ class WsServer implements HttpServerInterface {
      * Decorated component
      * @var \Ratchet\ComponentInterface
      */
-    private $delegate;
+    protected $delegate;
 
     /**
      * @var \SplObjectStorage


### PR DESCRIPTION
In code
```
class AuthWsServerWrapper extends WsServer
...
            $this->msgCb = function(ConnectionInterface $conn, MessageInterface $msg) {
                $this->delegate->onMessage($conn, $msg->getPayload());
            };
```
we need access to $this->delegate