### PR TITLE
Add ReturnTypeWillChange attribute to silence PHP 8.1 deprecations

### DIFF
--- a/src/Ratchet/Wamp/Topic.php
+++ b/src/Ratchet/Wamp/Topic.php
@@ -86,6 +86,7 @@ class Topic implements \IteratorAggregate, \Countable {
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator() {
         return $this->subscribers;
     }
@@ -93,6 +94,7 @@ class Topic implements \IteratorAggregate, \Countable {
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function count() {
         return $this->subscribers->count();
     }


### PR DESCRIPTION
PHP 8.1 adds tentative return types to a number of API symbols as noted in https://wiki.php.net/rfc/internal_method_return_types which will cause deprecation notices to be emitted if return types are missing.  Those can be silenced by adding the return types or adding the `#[ReturnTypeWillChange]` attribute until types can be added.

This PR adds the attribute (which is B/C with PHP 7 and older since the attribute syntax will be parsed as comments) to methods that will cause deprecations to be triggered, silencing these deprecation notices when running on PHP 8.1:

```
Return type of Ratchet\Wamp\Topic::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of Ratchet\Wamp\Topic::count() should either be compatible with Countable::count(): int, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```