### PR TITLE
Fix Dynamic Properties warnings for PHP >= 8.2

### DIFF
--- a/src/Ratchet/Server/IoConnection.php
+++ b/src/Ratchet/Server/IoConnection.php
@@ -6,6 +6,7 @@ use React\Socket\ConnectionInterface as ReactConn;
 /**
  * {@inheritdoc}
  */
+#[\AllowDynamicProperties]
 class IoConnection implements ConnectionInterface {
     /**
      * @var \React\Socket\ConnectionInterface


### PR DESCRIPTION
fix dynamic properties warnings for PHP >= 8.2