### PR TITLE
Update all http links to https

### DIFF
--- a/src/Ratchet/Server/FlashPolicy.php
+++ b/src/Ratchet/Server/FlashPolicy.php
@@ -9,8 +9,6 @@ use Ratchet\ConnectionInterface;
  * Be sure to run your server instance on port 843
  * By default this lets accepts everything, make sure you tighten the rules up for production
  * @final
- * @link http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html
- * @link http://learn.adobe.com/wiki/download/attachments/64389123/CrossDomain_PolicyFile_Specification.pdf?version=1
  * @link view-source:http://www.adobe.com/xml/schemas/PolicyFileSocket.xsd
  */
 class FlashPolicy implements MessageComponentInterface {

--- a/src/Ratchet/Session/Serialize/PhpBinaryHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpBinaryHandler.php
@@ -11,7 +11,7 @@ class PhpBinaryHandler implements HandlerInterface {
 
     /**
      * {@inheritdoc}
-     * @link http://ca2.php.net/manual/en/function.session-decode.php#108037 Code from this comment on php.net
+     * @link https://www.php.net/manual/en/function.session-decode.php#108037 Code from this comment on php.net
      */
     public function unserialize($raw) {
         $returnData = array();

--- a/src/Ratchet/Session/Serialize/PhpHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpHandler.php
@@ -22,7 +22,7 @@ class PhpHandler implements HandlerInterface {
 
     /**
      * {@inheritdoc}
-     * @link http://ca2.php.net/manual/en/function.session-decode.php#108037 Code from this comment on php.net
+     * @link https://www.php.net/manual/en/function.session-decode.php#108037 Code from this comment on php.net
      * @throws \UnexpectedValueException If there is a problem parsing the data
      */
     public function unserialize($raw) {

--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -7,7 +7,6 @@ use Ratchet\ConnectionInterface;
 /**
  * WebSocket Application Messaging Protocol
  *
- * @link http://wamp.ws/spec
  * @link https://github.com/oberstet/autobahn-js
  *
  * +--------------+----+------------------+

--- a/src/Ratchet/Wamp/WampServer.php
+++ b/src/Ratchet/Wamp/WampServer.php
@@ -7,9 +7,7 @@ use Ratchet\ConnectionInterface;
 /**
  * Enable support for the official WAMP sub-protocol in your application
  * WAMP allows for Pub/Sub and RPC
- * @link http://wamp.ws The WAMP specification
- * @link https://github.com/oberstet/autobahn-js Souce for client side library
- * @link http://autobahn.s3.amazonaws.com/js/autobahn.min.js Minified client side library
+ * @link https://github.com/oberstet/autobahn-js Source for client side library
  */
 class WampServer implements MessageComponentInterface, WsServerInterface {
     /**

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -19,8 +19,8 @@ use GuzzleHttp\Psr7\Message;
 /**
  * The adapter to handle WebSocket requests/responses
  * This is a mediator between the Server and your application to handle real-time messaging through a web browser
- * @link http://ca.php.net/manual/en/ref.http.php
- * @link http://dev.w3.org/html5/websockets/
+ * @link https://www.php.net/manual/en/ref.http.php
+ * @link https://websockets.spec.whatwg.org
  */
 class WsServer implements HttpServerInterface {
     use CloseResponseTrait;


### PR DESCRIPTION
Though almost all are in docs, these were being flagged in static analysis
Also removed some broken links, e.g. wamp.ws now forwards to some gambling site