### PR TITLE
PHP 8.4 Implicitly marking parameter <x> as nullable is deprecated 

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -63,7 +63,7 @@ class App {
      * @param LoopInterface $loop       Specific React\EventLoop to bind the application to. null will create one for you.
      * @param array         $context
      */
-    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', LoopInterface $loop = null, $context = array()) {
+    public function __construct($httpHost = 'localhost', $port = 8080, $address = '127.0.0.1', ?LoopInterface $loop = null, $context = array()) {
         if (extension_loaded('xdebug') && getenv('RATCHET_DISABLE_XDEBUG_WARN') === false) {
             trigger_error('XDebug extension detected. Remember to disable this if performance testing or going live!', E_USER_WARNING);
         }

--- a/src/Ratchet/Http/HttpServerInterface.php
+++ b/src/Ratchet/Http/HttpServerInterface.php
@@ -10,5 +10,5 @@ interface HttpServerInterface extends MessageComponentInterface {
      * @param \Psr\Http\Message\RequestInterface    $request null is default because PHP won't let me overload; don't pass null!!!
      * @throws \UnexpectedValueException if a RequestInterface is not passed
      */
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null);
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null);
 }

--- a/src/Ratchet/Http/NoOpHttpServerController.php
+++ b/src/Ratchet/Http/NoOpHttpServerController.php
@@ -4,7 +4,7 @@ use Ratchet\ConnectionInterface;
 use Psr\Http\Message\RequestInterface;
 
 class NoOpHttpServerController implements HttpServerInterface {
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) {
     }
 
     public function onMessage(ConnectionInterface $from, $msg) {

--- a/src/Ratchet/Http/OriginCheck.php
+++ b/src/Ratchet/Http/OriginCheck.php
@@ -31,7 +31,7 @@ class OriginCheck implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) {
         $header = (string)$request->getHeader('Origin')[0];
         $origin = parse_url($header, PHP_URL_HOST) ?: $header;
 

--- a/src/Ratchet/Http/Router.php
+++ b/src/Ratchet/Http/Router.php
@@ -26,7 +26,7 @@ class Router implements HttpServerInterface {
      * {@inheritdoc}
      * @throws \UnexpectedValueException If a controller is not \Ratchet\Http\HttpServerInterface
      */
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) {
         if (null === $request) {
             throw new \UnexpectedValueException('$request can not be null');
         }

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -33,7 +33,7 @@ class IoServer {
      * @param \React\Socket\ServerInterface       $socket   The React socket server to run the Ratchet application off of
      * @param \React\EventLoop\LoopInterface|null $loop     The React looper to run the Ratchet application off of
      */
-    public function __construct(MessageComponentInterface $app, ServerInterface $socket, LoopInterface $loop = null) {
+    public function __construct(MessageComponentInterface $app, ServerInterface $socket, ?LoopInterface $loop = null) {
         if (false === strpos(PHP_VERSION, "hiphop")) {
             gc_enable();
         }

--- a/src/Ratchet/Session/SessionProvider.php
+++ b/src/Ratchet/Session/SessionProvider.php
@@ -70,7 +70,7 @@ class SessionProvider implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) {
         $sessionName = ini_get('session.name');
 
         $id = array_reduce($request->getHeader('Cookie'), function($accumulator, $cookie) use ($sessionName) {

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -104,7 +104,7 @@ class WsServer implements HttpServerInterface {
     /**
      * {@inheritdoc}
      */
-    public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) {
+    public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) {
         if (null === $request) {
             throw new \UnexpectedValueException('$request can not be null');
         }

--- a/tests/helpers/Ratchet/Mock/Component.php
+++ b/tests/helpers/Ratchet/Mock/Component.php
@@ -9,7 +9,7 @@ class Component implements MessageComponentInterface, WsServerInterface {
 
     public $protocols = array();
 
-    public function __construct(ComponentInterface $app = null) {
+    public function __construct(?ComponentInterface $app = null) {
         $this->last[__FUNCTION__] = func_get_args();
     }
 


### PR DESCRIPTION
Fixes Implicit Nullable Types for php8.4