### PR TITLE
Updated RFC6455 Dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   , "require": {
         "php": ">=5.4.2"
-      , "ratchet/rfc6455": "^0.3.1"
+      , "ratchet/rfc6455": "^0.4.0"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "react/event-loop": ">=0.4"
       , "guzzlehttp/psr7": "^1.7|^2.0"

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -15,6 +15,7 @@ use Ratchet\RFC6455\Handshake\ServerNegotiator;
 use Ratchet\RFC6455\Handshake\RequestVerifier;
 use React\EventLoop\LoopInterface;
 use GuzzleHttp\Psr7\Message;
+use GuzzleHttp\Psr7\HttpFactory;
 
 /**
  * The adapter to handle WebSocket requests/responses
@@ -86,7 +87,7 @@ class WsServer implements HttpServerInterface {
         $this->connections = new \SplObjectStorage;
 
         $this->closeFrameChecker   = new CloseFrameChecker;
-        $this->handshakeNegotiator = new ServerNegotiator(new RequestVerifier);
+        $this->handshakeNegotiator = new ServerNegotiator(new RequestVerifier, new HttpFactory());
         $this->handshakeNegotiator->setStrictSubProtocolCheck(true);
 
         if ($component instanceof WsServerInterface) {


### PR DESCRIPTION
This minor update enables the usage of both `cboden/ratchet` and `ratchet/pawl` packages together within same project, with the [RFC6455 incompatibility issue](https://github.com/ratchetphp/Pawl/issues/166) resolved.