### PR TITLE
Update test environment to fix running tests on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,13 @@
 name: "CI"
 
 on:
-  pull_request:
   push:
-    branches:
-      - "master"
-  schedule:
-    - cron: "42 3 * * *"
+  pull_request:
 
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:
@@ -32,7 +28,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 2
 
@@ -44,7 +40,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8",
+        "psr/http-message": "~1.0.1"
     }
 }

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -131,16 +131,28 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testWarningGettingNothing() {
+        if (!(error_reporting() & E_NOTICE)) {
+            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
+        }
+
         $this->setExpectedException('PHPUnit_Framework_Error');
         $var = $this->mock->nonExistant;
     }
 
     public function testWarningGettingNothingLevel1() {
+        if (!(error_reporting() & E_NOTICE)) {
+            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
+        }
+
         $this->setExpectedException('PHPUnit_Framework_Error');
         $var = $this->l1->nonExistant;
     }
 
     public function testWarningGettingNothingLevel2() {
+        if (!(error_reporting() & E_NOTICE)) {
+            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
+        }
+
         $this->setExpectedException('PHPUnit_Framework_Error');
         $var = $this->l2->nonExistant;
     }

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -47,6 +47,9 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
         //$this->assertTrue(is_int($this->app->last['onOpen'][0]->resourceId));
     }
 
+    /**
+     * @requires extension sockets
+     */
     public function testOnData() {
         $msg = 'Hello World!';
 
@@ -73,6 +76,9 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
         $this->tickLoop($this->server->loop);
     }
 
+    /**
+     * @requires extension sockets
+     */
     public function testOnClose() {
         $this->app->expects($this->once())->method('onClose')->with($this->isInstanceOf('\\Ratchet\\ConnectionInterface'));
 


### PR DESCRIPTION
This changset updates the test environment to fix running tests on GitHub Actions. This is part 1 of reviving Ratchet as discussed in #1054, finally unblocking future progress.

With these changes applied, the existing test suite will work again as is both locally and on GitHub Actions (CI). Once merged, I'll use this as a starting point to add add newer PHP 8+ version support as discussed in #1003 and elsewhere.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #856, https://github.com/reactphp/reactphp/pull/442, https://github.com/reactphp/socket/pull/299, https://github.com/clue/framework-x/pull/267 and others