### PR TITLE
Rename `master` branch to `0.4.x` and add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ratchet
 
-[![GitHub Actions][GA Image]][GA Link]
+[![CI status](https://github.com/ratchetphp/Ratchet/actions/workflows/ci.yml/badge.svg)](https://github.com/ratchetphp/Ratchet/actions)
 [![Autobahn Testsuite](https://img.shields.io/badge/Autobahn-passing-brightgreen.svg)](http://socketo.me/reports/ab/index.html)
 [![Latest Stable Version](https://poser.pugx.org/cboden/ratchet/v/stable.png)](https://packagist.org/packages/cboden/ratchet)
 
@@ -87,6 +87,25 @@ class MyChat implements MessageComponentInterface {
     conn.onopen = function(e) { conn.send('Hello Me!'); };
 ```
 
-[GA Image]: https://github.com/ratchetphp/Ratchet/workflows/CI/badge.svg
+## Install
 
-[GA Link]: https://github.com/ratchetphp/Ratchet/actions?query=workflow%3A%22CI%22+branch%3Amaster
+The recommended way to install this library is [through Composer](https://getcomposer.org/).
+[New to Composer?](https://getcomposer.org/doc/00-intro.md)
+
+This will install the latest supported version:
+
+```bash
+composer require cboden/ratchet:^0.4.4
+```
+
+See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
+
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.4 through PHP 7.4+ with limited support for PHP 8+.
+It's *highly recommended to use the latest supported PHP version* for this project.
+
+See above note about [Reviving Ratchet](#reviving-ratchet) for newer PHP support.
+
+## License
+
+MIT, see [LICENSE file](LICENSE).


### PR DESCRIPTION
This changeset suggests renaming the development branch to `0.4.x` and adds appropriate installation instructions. In particular, this makes it easier to install the v0.4 development version like this:

```bash
$ composer require cboden/ratchet:^0.4@dev
```

The same branch policy has been implemented in @ReactPHP a while back, see also https://github.com/reactphp/async/pull/29 for more details. Once this PR is merged, I will manually rename the `master` branch to `0.4.x`.

Builds on top of #1088, one step closer to reviving Ratchet as discussed in #1054