### PR TITLE
Update tests to support PHPUnit ^7.5 and psr/http-message ^2.0 on PHP 7.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^5.7 || ^4.8.36",
-        "psr/http-message": "~1.0.1"
+        "phpunit/phpunit": "^7.5 || ^5.7 || ^4.8.36"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^5.7 || ^4.8.36",
         "psr/http-message": "~1.0.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^6.5 || ^5.7 || ^4.8.36",
         "psr/http-message": "~1.0.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^6.5 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^7.5 || ^5.7 || ^4.8.36",
         "psr/http-message": "~1.0.1"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     forceCoversAnnotation="true"
-    mapTestClassNameToCoveredClassName="true"
     bootstrap="tests/bootstrap.php"
     colors="true"
     backupGlobals="false"
     backupStaticAttributes="false"
-    syntaxCheck="false"
     stopOnError="false"
 >
 
     <testsuites>
         <testsuite name="unit">
             <directory>./tests/unit/</directory>
-        </testsuite>
-    </testsuites>
-
-    <testsuites>
-        <testsuite name="integration">
-            <directory>./tests/integration/</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
+++ b/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ratchet;
 
-abstract class AbstractMessageComponentTestCase extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractMessageComponentTestCase extends TestCase {
     protected $_app;
     protected $_serv;
     protected $_conn;
@@ -24,7 +26,7 @@ abstract class AbstractMessageComponentTestCase extends \PHPUnit_Framework_TestC
     }
 
     public function isExpectedConnection() {
-        return new \PHPUnit_Framework_Constraint_IsInstanceOf($this->getConnectionClassString());
+        return $this->isInstanceOf($this->getConnectionClassString());
     }
 
     public function testOpen() {

--- a/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
+++ b/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
@@ -11,10 +11,10 @@ abstract class AbstractMessageComponentTestCase extends \PHPUnit_Framework_TestC
     abstract public function getComponentClassString();
 
     public function setUp() {
-        $this->_app  = $this->getMock($this->getComponentClassString());
+        $this->_app  = $this->getMockBuilder($this->getComponentClassString())->getMock();
         $decorator   = $this->getDecoratorClassString();
         $this->_serv = new $decorator($this->_app);
-        $this->_conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
 
         $this->doOpen($this->_conn);
     }
@@ -29,7 +29,7 @@ abstract class AbstractMessageComponentTestCase extends \PHPUnit_Framework_TestC
 
     public function testOpen() {
         $this->_app->expects($this->once())->method('onOpen')->with($this->isExpectedConnection());
-        $this->doOpen($this->getMock('\Ratchet\ConnectionInterface'));
+        $this->doOpen($this->getMockBuilder('Ratchet\ConnectionInterface')->getMock());
     }
 
     public function testOnClose() {

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Ratchet;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Mock\ConnectionDecorator;
 
 /**
  * @covers Ratchet\AbstractConnectionDecorator
  * @covers Ratchet\ConnectionInterface
  */
-class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
+class AbstractConnectionDecoratorTest extends TestCase {
     protected $mock;
     protected $l1;
     protected $l2;
@@ -135,7 +136,11 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
         }
 
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
         $var = $this->mock->nonExistant;
     }
 
@@ -144,7 +149,11 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
         }
 
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
         $var = $this->l1->nonExistant;
     }
 
@@ -153,7 +162,11 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
         }
 
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
         $var = $this->l2->nonExistant;
     }
 }

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -12,7 +12,7 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
     protected $l2;
 
     public function setUp() {
-        $this->mock = $this->getMock('\Ratchet\ConnectionInterface');
+        $this->mock = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->l1   = new ConnectionDecorator($this->mock);
         $this->l2   = new ConnectionDecorator($this->l1);
     }
@@ -84,7 +84,7 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testGetConnection() {
-        $class  = new \ReflectionClass('\\Ratchet\\AbstractConnectionDecorator');
+        $class  = new \ReflectionClass('Ratchet\\AbstractConnectionDecorator');
         $method = $class->getMethod('getConnection');
         $method->setAccessible(true);
 
@@ -94,7 +94,7 @@ class AbstractConnectionDecoratorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testGetConnectionLevel2() {
-        $class  = new \ReflectionClass('\\Ratchet\\AbstractConnectionDecorator');
+        $class  = new \ReflectionClass('Ratchet\\AbstractConnectionDecorator');
         $method = $class->getMethod('getConnection');
         $method->setAccessible(true);
 

--- a/tests/unit/Http/HttpRequestParserTest.php
+++ b/tests/unit/Http/HttpRequestParserTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Ratchet\Http;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Ratchet\Http\HttpRequestParser
  */
-class HttpRequestParserTest extends \PHPUnit_Framework_TestCase {
+class HttpRequestParserTest extends TestCase {
     protected $parser;
 
     public function setUp() {
@@ -36,7 +38,11 @@ class HttpRequestParserTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertNull($this->parser->onMessage($conn, "GET / HTTP/1.1\r\n"));
 
-        $this->setExpectedException('OverflowException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('OverflowException');
+        } else {
+            $this->setExpectedException('OverflowException');
+        }
 
         $this->parser->onMessage($conn, "Header-Is: Too Big");
     }

--- a/tests/unit/Http/HttpRequestParserTest.php
+++ b/tests/unit/Http/HttpRequestParserTest.php
@@ -30,7 +30,7 @@ class HttpRequestParserTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBufferOverflowResponse() {
-        $conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
 
         $this->parser->maxSize = 20;
 
@@ -42,9 +42,9 @@ class HttpRequestParserTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testReturnTypeIsRequest() {
-        $conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $return = $this->parser->onMessage($conn, "GET / HTTP/1.1\r\nHost: socketo.me\r\n\r\n");
 
-        $this->assertInstanceOf('\Psr\Http\Message\RequestInterface', $return);
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $return);
     }
 }

--- a/tests/unit/Http/HttpServerTest.php
+++ b/tests/unit/Http/HttpServerTest.php
@@ -12,15 +12,15 @@ class HttpServerTest extends AbstractMessageComponentTestCase {
     }
 
     public function getConnectionClassString() {
-        return '\Ratchet\ConnectionInterface';
+        return 'Ratchet\ConnectionInterface';
     }
 
     public function getDecoratorClassString() {
-        return '\Ratchet\Http\HttpServer';
+        return 'Ratchet\Http\HttpServer';
     }
 
     public function getComponentClassString() {
-        return '\Ratchet\Http\HttpServerInterface';
+        return 'Ratchet\Http\HttpServerInterface';
     }
 
     public function testOpen() {

--- a/tests/unit/Http/OriginCheckTest.php
+++ b/tests/unit/Http/OriginCheckTest.php
@@ -9,11 +9,12 @@ class OriginCheckTest extends AbstractMessageComponentTestCase {
     protected $_reqStub;
 
     public function setUp() {
-        $this->_reqStub = $this->getMock('Psr\Http\Message\RequestInterface');
+        $this->_reqStub = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $this->_reqStub->expects($this->any())->method('getHeader')->will($this->returnValue(['localhost']));
 
         parent::setUp();
 
+        assert($this->_serv instanceof OriginCheck);
         $this->_serv->allowedOrigins[] = 'localhost';
     }
 
@@ -22,15 +23,15 @@ class OriginCheckTest extends AbstractMessageComponentTestCase {
     }
 
     public function getConnectionClassString() {
-        return '\Ratchet\ConnectionInterface';
+        return 'Ratchet\ConnectionInterface';
     }
 
     public function getDecoratorClassString() {
-        return '\Ratchet\Http\OriginCheck';
+        return 'Ratchet\Http\OriginCheck';
     }
 
     public function getComponentClassString() {
-        return '\Ratchet\Http\HttpServerInterface';
+        return 'Ratchet\Http\HttpServerInterface';
     }
 
     public function testCloseOnNonMatchingOrigin() {

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -19,18 +19,18 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
     protected $_req;
 
     public function setUp() {
-        $this->_conn = $this->getMock('\Ratchet\ConnectionInterface');
-        $this->_uri  = $this->getMock('Psr\Http\Message\UriInterface');
-        $this->_req  = $this->getMock('\Psr\Http\Message\RequestInterface');
+        $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->_uri  = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
+        $this->_req  = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $this->_req
             ->expects($this->any())
             ->method('getUri')
             ->will($this->returnValue($this->_uri));
-        $this->_matcher = $this->getMock('Symfony\Component\Routing\Matcher\UrlMatcherInterface');
+        $this->_matcher = $this->getMockBuilder('Symfony\Component\Routing\Matcher\UrlMatcherInterface')->getMock();
         $this->_matcher
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($this->getMock('Symfony\Component\Routing\RequestContext')));
+            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Routing\RequestContext')->getMock()));
         $this->_router  = new Router($this->_matcher);
 
         $this->_uri->expects($this->any())->method('getPath')->will($this->returnValue('ws://doesnt.matter/'));
@@ -40,7 +40,9 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
             return true;
         }))->will($this->returnSelf());
         $this->_uri->expects($this->any())->method('getQuery')->will($this->returnCallback([$this, 'getResult']));
+        $this->_uri->expects($this->any())->method('getHost')->willReturn('example.com');
         $this->_req->expects($this->any())->method('withUri')->will($this->returnSelf());
+        $this->_req->expects($this->any())->method('getMethod')->willReturn('GET');
     }
 
     public function testFourOhFour() {
@@ -53,22 +55,22 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testNullRequest() {
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->setExpectedException('UnexpectedValueException');
         $this->_router->onOpen($this->_conn);
     }
 
     public function testControllerIsMessageComponentInterface() {
-        $this->setExpectedException('\UnexpectedValueException');
+        $this->setExpectedException('UnexpectedValueException');
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => new \StdClass)));
         $this->_router->onOpen($this->_conn, $this->_req);
     }
 
     public function testControllerOnOpen() {
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));
         $this->_router->onOpen($this->_conn, $this->_req);
 
-        $expectedConn = new \PHPUnit_Framework_Constraint_IsInstanceOf('\Ratchet\ConnectionInterface');
+        $expectedConn = new \PHPUnit_Framework_Constraint_IsInstanceOf('Ratchet\ConnectionInterface');
         $controller->expects($this->once())->method('onOpen')->with($expectedConn, $this->_req);
 
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));
@@ -77,7 +79,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 
     public function testControllerOnMessageBubbles() {
         $message = "The greatest trick the Devil ever pulled was convincing the world he didn't exist";
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         $controller->expects($this->once())->method('onMessage')->with($this->_conn, $message);
 
         $this->_conn->controller = $controller;
@@ -86,7 +88,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testControllerOnCloseBubbles() {
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         $controller->expects($this->once())->method('onClose')->with($this->_conn);
 
         $this->_conn->controller = $controller;
@@ -96,7 +98,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 
     public function testControllerOnErrorBubbles() {
         $e= new \Exception('One cannot be betrayed if one has no exceptions');
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         $controller->expects($this->once())->method('onError')->with($this->_conn, $e);
 
         $this->_conn->controller = $controller;
@@ -106,12 +108,12 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 
     public function testRouterGeneratesRouteParameters() {
         /** @var $controller WsServerInterface */
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         /** @var $matcher UrlMatcherInterface */
         $this->_matcher->expects($this->any())->method('match')->will(
             $this->returnValue(['_controller' => $controller, 'foo' => 'bar', 'baz' => 'qux'])
         );
-        $conn = $this->getMock('Ratchet\Mock\Connection');
+        $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
 
         $router = new Router($this->_matcher);
 
@@ -121,13 +123,13 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testQueryParams() {
-        $controller = $this->getMockBuilder('\Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder('Ratchet\WebSocket\WsServer')->disableOriginalConstructor()->getMock();
         $this->_matcher->expects($this->any())->method('match')->will(
             $this->returnValue(['_controller' => $controller, 'foo' => 'bar', 'baz' => 'qux'])
         );
 
-        $conn    = $this->getMock('Ratchet\Mock\Connection');
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
+        $conn    = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $uri = new \GuzzleHttp\Psr7\Uri('ws://doesnt.matter/endpoint?hello=world&foo=nope');
 
         $request->expects($this->any())->method('getUri')->will($this->returnCallback(function() use (&$uri) {
@@ -138,6 +140,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
 
             return true;
         }))->will($this->returnSelf());
+        $request->expects($this->once())->method('getMethod')->willReturn('GET');
 
         $router = new Router($this->_matcher);
         $router->onOpen($conn, $request);

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -39,7 +39,6 @@ class RouterTest extends TestCase {
 
             return true;
         }))->will($this->returnSelf());
-        $this->_uri->expects($this->any())->method('getQuery')->will($this->returnCallback([$this, 'getResult']));
         $this->_uri->expects($this->any())->method('getHost')->willReturn('example.com');
         $this->_req->expects($this->any())->method('withUri')->will($this->returnSelf());
         $this->_req->expects($this->any())->method('getMethod')->willReturn('GET');
@@ -123,11 +122,12 @@ class RouterTest extends TestCase {
         );
         $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
 
+        $this->_uri->expects($this->once())->method('withQuery')->with('foo=bar&baz=qux')->willReturnSelf();
+        $this->_req->expects($this->once())->method('withUri')->will($this->returnSelf());
+
         $router = new Router($this->_matcher);
 
         $router->onOpen($conn, $this->_req);
-
-        $this->assertEquals('foo=bar&baz=qux', $this->_req->getUri()->getQuery());
     }
 
     public function testQueryParams() {

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Ratchet\Http;
+use PHPUnit\Framework\TestCase;
 use Ratchet\WebSocket\WsServerInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
@@ -7,11 +8,10 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 
-
 /**
  * @covers Ratchet\Http\Router
  */
-class RouterTest extends \PHPUnit_Framework_TestCase {
+class RouterTest extends TestCase {
     protected $_router;
     protected $_matcher;
     protected $_conn;
@@ -55,12 +55,20 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testNullRequest() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
         $this->_router->onOpen($this->_conn);
     }
 
     public function testControllerIsMessageComponentInterface() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => new \StdClass)));
         $this->_router->onOpen($this->_conn, $this->_req);
     }
@@ -70,7 +78,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));
         $this->_router->onOpen($this->_conn, $this->_req);
 
-        $expectedConn = new \PHPUnit_Framework_Constraint_IsInstanceOf('Ratchet\ConnectionInterface');
+        $expectedConn = $this->isInstanceOf('Ratchet\ConnectionInterface');
         $controller->expects($this->once())->method('onOpen')->with($expectedConn, $this->_req);
 
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));

--- a/tests/unit/Server/EchoServerTest.php
+++ b/tests/unit/Server/EchoServerTest.php
@@ -7,7 +7,7 @@ class EchoServerTest extends \PHPUnit_Framework_TestCase {
     protected $_comp;
 
     public function setUp() {
-        $this->_conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->_comp = new EchoServer;
     }
 

--- a/tests/unit/Server/EchoServerTest.php
+++ b/tests/unit/Server/EchoServerTest.php
@@ -1,8 +1,9 @@
 <?php
 namespace Ratchet\Server;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Server\EchoServer;
 
-class EchoServerTest extends \PHPUnit_Framework_TestCase {
+class EchoServerTest extends TestCase {
     protected $_conn;
     protected $_comp;
 

--- a/tests/unit/Server/FlashPolicyComponentTest.php
+++ b/tests/unit/Server/FlashPolicyComponentTest.php
@@ -123,7 +123,7 @@ class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testErrorClosesConnection() {
-        $conn = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $conn->expects($this->once())->method('close');
 
         $this->_policy->onError($conn, new \Exception);
@@ -132,7 +132,7 @@ class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
     public function testOnMessageSendsString() {
         $this->_policy->addAllowedAccess('*', '*');
 
-        $conn = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $conn->expects($this->once())->method('send')->with($this->isType('string'));
 
         $this->_policy->onMessage($conn, ' ');
@@ -140,13 +140,13 @@ class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
 
     public function testOnOpenExists() {
         $this->assertTrue(method_exists($this->_policy, 'onOpen'));
-        $conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->_policy->onOpen($conn);
     }
 
     public function testOnCloseExists() {
         $this->assertTrue(method_exists($this->_policy, 'onClose'));
-        $conn = $this->getMock('\Ratchet\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->_policy->onClose($conn);
     }
 }

--- a/tests/unit/Server/FlashPolicyComponentTest.php
+++ b/tests/unit/Server/FlashPolicyComponentTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Application\Server;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Server\FlashPolicy;
 
 /**
  * @covers Ratchet\Server\FlashPolicy
  */
-class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
+class FlashPolicyTest extends TestCase {
 
     protected $_policy;
 
@@ -22,12 +23,20 @@ class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testInvalidPolicyReader() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
         $this->_policy->renderPolicy();
     }
 
     public function testInvalidDomainPolicyReader() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
         $this->_policy->setSiteControl('all');
         $this->_policy->addAllowedAccess('dev.example.*', '*');
         $this->_policy->renderPolicy();
@@ -111,13 +120,21 @@ class FlashPolicyTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testAddAllowedAccessOnlyAcceptsValidPorts() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
 
         $this->_policy->addAllowedAccess('*', 'nope');
     }
 
     public function testSetSiteControlThrowsException() {
-        $this->setExpectedException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
 
         $this->_policy->setSiteControl('nope');
     }

--- a/tests/unit/Server/IoConnectionTest.php
+++ b/tests/unit/Server/IoConnectionTest.php
@@ -10,7 +10,7 @@ class IoConnectionTest extends \PHPUnit_Framework_TestCase {
     protected $conn;
 
     public function setUp() {
-        $this->sock = $this->getMock('\\React\\Socket\\ConnectionInterface');
+        $this->sock = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
         $this->conn = new IoConnection($this->sock);
     }
 

--- a/tests/unit/Server/IoConnectionTest.php
+++ b/tests/unit/Server/IoConnectionTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Application\Server;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Server\IoConnection;
 
 /**
  * @covers Ratchet\Server\IoConnection
  */
-class IoConnectionTest extends \PHPUnit_Framework_TestCase {
+class IoConnectionTest extends TestCase {
     protected $sock;
     protected $conn;
 

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -26,7 +26,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function setUp() {
-        $this->app = $this->getMock('\\Ratchet\\MessageComponentInterface');
+        $this->app = $this->getMockBuilder('Ratchet\\MessageComponentInterface')->getMock();
 
         $loop = new StreamSelectLoop;
         $this->reactor = new Server(0, $loop);
@@ -37,7 +37,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testOnOpen() {
-        $this->app->expects($this->once())->method('onOpen')->with($this->isInstanceOf('\\Ratchet\\ConnectionInterface'));
+        $this->app->expects($this->once())->method('onOpen')->with($this->isInstanceOf('Ratchet\\ConnectionInterface'));
 
         $client = stream_socket_client("tcp://localhost:{$this->port}");
 
@@ -54,7 +54,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
         $msg = 'Hello World!';
 
         $this->app->expects($this->once())->method('onMessage')->with(
-            $this->isInstanceOf('\\Ratchet\\ConnectionInterface')
+            $this->isInstanceOf('Ratchet\\ConnectionInterface')
           , $msg
         );
 
@@ -80,7 +80,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
      * @requires extension sockets
      */
     public function testOnClose() {
-        $this->app->expects($this->once())->method('onClose')->with($this->isInstanceOf('\\Ratchet\\ConnectionInterface'));
+        $this->app->expects($this->once())->method('onClose')->with($this->isInstanceOf('Ratchet\\ConnectionInterface'));
 
         $client = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         socket_set_option($client, SOL_SOCKET, SO_REUSEADDR, 1);
@@ -98,7 +98,7 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testFactory() {
-        $this->assertInstanceOf('\\Ratchet\\Server\\IoServer', IoServer::factory($this->app, 0));
+        $this->assertInstanceOf('Ratchet\\Server\\IoServer', IoServer::factory($this->app, 0));
     }
 
     public function testNoLoopProvidedError() {
@@ -109,8 +109,8 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testOnErrorPassesException() {
-        $conn = $this->getMock('\\React\\Socket\\ConnectionInterface');
-        $conn->decor = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $conn = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
+        $conn->decor = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $err  = new \Exception("Nope");
 
         $this->app->expects($this->once())->method('onError')->with($conn->decor, $err);
@@ -121,12 +121,12 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     public function onErrorCalledWhenExceptionThrown() {
         $this->markTestIncomplete("Need to learn how to throw an exception from a mock");
 
-        $conn = $this->getMock('\\React\\Socket\\ConnectionInterface');
+        $conn = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
         $this->server->handleConnect($conn);
 
         $e = new \Exception;
-        $this->app->expects($this->once())->method('onMessage')->with($this->isInstanceOf('\\Ratchet\\ConnectionInterface'), 'f')->will($e);
-        $this->app->expects($this->once())->method('onError')->with($this->instanceOf('\\Ratchet\\ConnectionInterface', $e));
+        $this->app->expects($this->once())->method('onMessage')->with($this->isInstanceOf('Ratchet\\ConnectionInterface'), 'f')->will($e);
+        $this->app->expects($this->once())->method('onError')->with($this->instanceOf('Ratchet\\ConnectionInterface', $e));
 
         $this->server->handleData('f', $conn);
     }

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -1,6 +1,6 @@
 <?php
 namespace Ratchet\Server;
-use Ratchet\Server\IoServer;
+use PHPUnit\Framework\TestCase;
 use React\EventLoop\StreamSelectLoop;
 use React\EventLoop\LoopInterface;
 use React\Socket\Server;
@@ -8,7 +8,7 @@ use React\Socket\Server;
 /**
  * @covers Ratchet\Server\IoServer
  */
-class IoServerTest extends \PHPUnit_Framework_TestCase {
+class IoServerTest extends TestCase {
     protected $server;
 
     protected $app;
@@ -102,7 +102,11 @@ class IoServerTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testNoLoopProvidedError() {
-        $this->setExpectedException('RuntimeException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('RuntimeException');
+        } else {
+            $this->setExpectedException('RuntimeException');
+        }
 
         $io   = new IoServer($this->app, $this->reactor);
         $io->run();

--- a/tests/unit/Server/IpBlackListComponentTest.php
+++ b/tests/unit/Server/IpBlackListComponentTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Server;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Server\IpBlackList;
 
 /**
  * @covers Ratchet\Server\IpBlackList
  */
-class IpBlackListTest extends \PHPUnit_Framework_TestCase {
+class IpBlackListTest extends TestCase {
     protected $blocker;
     protected $mock;
 

--- a/tests/unit/Server/IpBlackListComponentTest.php
+++ b/tests/unit/Server/IpBlackListComponentTest.php
@@ -10,7 +10,7 @@ class IpBlackListTest extends \PHPUnit_Framework_TestCase {
     protected $mock;
 
     public function setUp() {
-        $this->mock = $this->getMock('\\Ratchet\\MessageComponentInterface');
+        $this->mock = $this->getMockBuilder('Ratchet\\MessageComponentInterface')->getMock();
         $this->blocker = new IpBlackList($this->mock);
     }
 
@@ -113,11 +113,11 @@ class IpBlackListTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testUnblockingSilentlyFails() {
-        $this->assertInstanceOf('\\Ratchet\\Server\\IpBlackList', $this->blocker->unblockAddress('localhost'));
+        $this->assertInstanceOf('Ratchet\\Server\\IpBlackList', $this->blocker->unblockAddress('localhost'));
     }
 
     protected function newConn() {
-        $conn = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $conn->remoteAddress = '127.0.0.1';
 
         return $conn;

--- a/tests/unit/Session/Serialize/PhpHandlerTest.php
+++ b/tests/unit/Session/Serialize/PhpHandlerTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Session\Serialize;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Session\Serialize\PhpHandler;
 
 /**
  * @covers Ratchet\Session\Serialize\PhpHandler
  */
-class PhpHandlerTest extends \PHPUnit_Framework_TestCase {
+class PhpHandlerTest extends TestCase {
     protected $_handler;
 
     public function setUp() {

--- a/tests/unit/Session/SessionComponentTest.php
+++ b/tests/unit/Session/SessionComponentTest.php
@@ -26,15 +26,15 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
     }
 
     public function getConnectionClassString() {
-        return '\Ratchet\ConnectionInterface';
+        return 'Ratchet\ConnectionInterface';
     }
 
     public function getDecoratorClassString() {
-        return '\Ratchet\NullComponent';
+        return 'Ratchet\NullComponent';
     }
 
     public function getComponentClassString() {
-        return '\Ratchet\Http\HttpServerInterface';
+        return 'Ratchet\Http\HttpServerInterface';
     }
 
     public function classCaseProvider() {
@@ -48,11 +48,11 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
      * @dataProvider classCaseProvider
      */
     public function testToClassCase($in, $out) {
-        $ref = new \ReflectionClass('\\Ratchet\\Session\\SessionProvider');
+        $ref = new \ReflectionClass('Ratchet\\Session\\SessionProvider');
         $method = $ref->getMethod('toClassCase');
         $method->setAccessible(true);
 
-        $component = new SessionProvider($this->getMock($this->getComponentClassString()), $this->getMock('\SessionHandlerInterface'));
+        $component = new SessionProvider($this->getMockBuilder($this->getComponentClassString())->getMock(), $this->getMockBuilder('SessionHandlerInterface')->getMock());
         $this->assertEquals($out, $method->invokeArgs($component, array($in)));
     }
 
@@ -81,10 +81,10 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
         $pdoHandler = new PdoSessionHandler($pdo, $dbOptions);
         $pdoHandler->write($sessionId, '_sf2_attributes|a:2:{s:5:"hello";s:5:"world";s:4:"last";i:1332872102;}_sf2_flashes|a:0:{}');
 
-        $component  = new SessionProvider($this->getMock($this->getComponentClassString()), $pdoHandler, array('auto_start' => 1));
-        $connection = $this->getMock('Ratchet\\ConnectionInterface');
+        $component  = new SessionProvider($this->getMockBuilder($this->getComponentClassString())->getMock(), $pdoHandler, array('auto_start' => 1));
+        $connection = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
 
-        $headers = $this->getMock('Psr\Http\Message\RequestInterface');
+        $headers = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $headers->expects($this->once())->method('getHeader')->will($this->returnValue([ini_get('session.name') . "={$sessionId};"]));
 
         $component->onOpen($connection, $headers);
@@ -93,9 +93,9 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
     }
 
     protected function newConn() {
-        $conn = $this->getMock('Ratchet\ConnectionInterface');
+        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
 
-        $headers = $this->getMock('Psr\Http\Message\Request', array('getCookie'), array('POST', '/', array()));
+        $headers = $this->getMockBuilder('Psr\Http\Message\Request', array('getCookie'), array('POST', '/', array()))->getMock();
         $headers->expects($this->once())->method('getCookie', array(ini_get('session.name')))->will($this->returnValue(null));
 
         return $conn;
@@ -113,12 +113,12 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
         }
 
         ini_set('session.serialize_handler', 'wddx');
-        $this->setExpectedException('\RuntimeException');
-        new SessionProvider($this->getMock($this->getComponentClassString()), $this->getMock('\SessionHandlerInterface'));
+        $this->setExpectedException('RuntimeException');
+        new SessionProvider($this->getMockBuilder($this->getComponentClassString())->getMock(), $this->getMockBuilder('SessionHandlerInterface')->getMock());
     }
 
     protected function doOpen($conn) {
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $request->expects($this->any())->method('getHeader')->will($this->returnValue([]));
 
         $this->_serv->onOpen($conn, $request);

--- a/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
+++ b/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Session\Storage;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Session\Serialize\PhpHandler;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler;
 
-class VirtualSessionStoragePDOTest extends \PHPUnit_Framework_TestCase {
+class VirtualSessionStoragePDOTest extends TestCase {
     /**
      * @var VirtualSessionStorage
      */

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Ratchet\Wamp;
+use PHPUnit\Framework\TestCase;
 use Ratchet\Mock\Connection;
 use Ratchet\Mock\WampComponent as TestComponent;
 
@@ -8,7 +9,7 @@ use Ratchet\Mock\WampComponent as TestComponent;
  * @covers \Ratchet\Wamp\WampServerInterface
  * @covers \Ratchet\Wamp\WampConnection
  */
-class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
+class ServerProtocolTest extends TestCase {
     protected $_comp;
 
     protected $_app;
@@ -36,7 +37,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider invalidMessageProvider
      */
     public function testInvalidMessages($type) {
-        $this->setExpectedException('Ratchet\Wamp\Exception');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
@@ -222,7 +227,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testMessageMustBeJson() {
-        $this->setExpectedException('Ratchet\\Wamp\\JsonException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = new Connection;
 
@@ -259,7 +268,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider badFormatProvider
      */
     public function testValidJsonButInvalidProtocol($message) {
-        $this->setExpectedException('Ratchet\Wamp\Exception');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
@@ -267,7 +280,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadClientInputFromNonStringTopic() {
-        $this->setExpectedException('Ratchet\Wamp\Exception');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
@@ -276,7 +293,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadPrefixWithNonStringTopic() {
-        $this->setExpectedException('Ratchet\Wamp\Exception');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
@@ -285,7 +306,11 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadPublishWithNonStringTopic() {
-        $this->setExpectedException('Ratchet\Wamp\Exception');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Ratchet\Wamp\Exception');
+        } else {
+            $this->setExpectedException('Ratchet\Wamp\Exception');
+        }
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -36,7 +36,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider invalidMessageProvider
      */
     public function testInvalidMessages($type) {
-        $this->setExpectedException('\Ratchet\Wamp\Exception');
+        $this->setExpectedException('Ratchet\Wamp\Exception');
 
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
@@ -180,7 +180,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
         $this->_comp->onOpen($conn);
         $this->_comp->onClose($conn);
 
-        $class  = new \ReflectionClass('\\Ratchet\\Wamp\\WampConnection');
+        $class  = new \ReflectionClass('Ratchet\\Wamp\\WampConnection');
         $method = $class->getMethod('getConnection');
         $method->setAccessible(true);
 
@@ -197,7 +197,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
         $this->_comp->onOpen($conn);
         $this->_comp->onError($conn, $e);
 
-        $class  = new \ReflectionClass('\\Ratchet\\Wamp\\WampConnection');
+        $class  = new \ReflectionClass('Ratchet\\Wamp\\WampConnection');
         $method = $class->getMethod('getConnection');
         $method->setAccessible(true);
 
@@ -222,7 +222,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testMessageMustBeJson() {
-        $this->setExpectedException('\\Ratchet\\Wamp\\JsonException');
+        $this->setExpectedException('Ratchet\\Wamp\\JsonException');
 
         $conn = new Connection;
 
@@ -241,7 +241,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testWampOnMessageApp() {
-        $app = $this->getMock('\\Ratchet\\Wamp\\WampServerInterface');
+        $app = $this->getMockBuilder('Ratchet\\Wamp\\WampServerInterface')->getMock();
         $wamp = new ServerProtocol($app);
 
         $this->assertContains('wamp', $wamp->getSubProtocols());
@@ -259,7 +259,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider badFormatProvider
      */
     public function testValidJsonButInvalidProtocol($message) {
-        $this->setExpectedException('\Ratchet\Wamp\Exception');
+        $this->setExpectedException('Ratchet\Wamp\Exception');
 
         $conn = $this->newConn();
         $this->_comp->onOpen($conn);
@@ -267,7 +267,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadClientInputFromNonStringTopic() {
-        $this->setExpectedException('\Ratchet\Wamp\Exception');
+        $this->setExpectedException('Ratchet\Wamp\Exception');
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
@@ -276,7 +276,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadPrefixWithNonStringTopic() {
-        $this->setExpectedException('\Ratchet\Wamp\Exception');
+        $this->setExpectedException('Ratchet\Wamp\Exception');
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);
@@ -285,7 +285,7 @@ class ServerProtocolTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testBadPublishWithNonStringTopic() {
-        $this->setExpectedException('\Ratchet\Wamp\Exception');
+        $this->setExpectedException('Ratchet\Wamp\Exception');
 
         $conn = new WampConnection($this->newConn());
         $this->_comp->onOpen($conn);

--- a/tests/unit/Wamp/TopicManagerTest.php
+++ b/tests/unit/Wamp/TopicManagerTest.php
@@ -18,8 +18,8 @@ class TopicManagerTest extends \PHPUnit_Framework_TestCase {
     private $conn;
 
     public function setUp() {
-        $this->conn = $this->getMock('\Ratchet\ConnectionInterface');
-        $this->mock = $this->getMock('\Ratchet\Wamp\WampServerInterface');
+        $this->conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->mock = $this->getMockBuilder('Ratchet\Wamp\WampServerInterface')->getMock();
         $this->mngr = new TopicManager($this->mock);
 
         $this->conn->WAMP = new \StdClass;
@@ -217,7 +217,7 @@ class TopicManagerTest extends \PHPUnit_Framework_TestCase {
 
     public function testGetSubProtocolsBubbles() {
         $subs = array('hello', 'world');
-        $app  = $this->getMock('Ratchet\Wamp\Stub\WsWampServerInterface');
+        $app  = $this->getMockBuilder('Ratchet\Wamp\Stub\WsWampServerInterface')->getMock();
         $app->expects($this->once())->method('getSubProtocols')->will($this->returnValue($subs));
         $mngr = new TopicManager($app);
 

--- a/tests/unit/Wamp/TopicManagerTest.php
+++ b/tests/unit/Wamp/TopicManagerTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Ratchet\Wamp;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Ratchet\Wamp\TopicManager
  */
-class TopicManagerTest extends \PHPUnit_Framework_TestCase {
+class TopicManagerTest extends TestCase {
     private $mock;
 
     /**

--- a/tests/unit/Wamp/TopicTest.php
+++ b/tests/unit/Wamp/TopicTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Ratchet\Wamp;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Ratchet\Wamp\Topic
  */
-class TopicTest extends \PHPUnit_Framework_TestCase {
+class TopicTest extends TestCase {
     public function testGetId() {
         $id    = uniqid();
         $topic = new Topic($id);

--- a/tests/unit/Wamp/TopicTest.php
+++ b/tests/unit/Wamp/TopicTest.php
@@ -40,8 +40,8 @@ class TopicTest extends \PHPUnit_Framework_TestCase {
         $name = 'Batman';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
-        $second = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
 
         $first->expects($this->once())
               ->method('send')
@@ -63,9 +63,9 @@ class TopicTest extends \PHPUnit_Framework_TestCase {
         $name = 'Excluding';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
-        $second = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
-        $third  = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
 
         $first->expects($this->once())
             ->method('send')
@@ -90,9 +90,9 @@ class TopicTest extends \PHPUnit_Framework_TestCase {
         $name = 'Eligible';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
-        $second = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
-        $third  = $this->getMock('Ratchet\\Wamp\\WampConnection', array('send'), array($this->getMock('\\Ratchet\\ConnectionInterface')));
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
 
         $first->expects($this->once())
             ->method('send')
@@ -159,6 +159,6 @@ class TopicTest extends \PHPUnit_Framework_TestCase {
     }
 
     protected function newConn() {
-        return new WampConnection($this->getMock('\\Ratchet\\ConnectionInterface'));
+        return new WampConnection($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock());
     }
 }

--- a/tests/unit/Wamp/WampConnectionTest.php
+++ b/tests/unit/Wamp/WampConnectionTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Ratchet\Wamp;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @covers Ratchet\Wamp\WampConnection
  */
-class WampConnectionTest extends \PHPUnit_Framework_TestCase {
+class WampConnectionTest extends TestCase {
     protected $conn;
     protected $mock;
 

--- a/tests/unit/Wamp/WampConnectionTest.php
+++ b/tests/unit/Wamp/WampConnectionTest.php
@@ -9,7 +9,7 @@ class WampConnectionTest extends \PHPUnit_Framework_TestCase {
     protected $mock;
 
     public function setUp() {
-        $this->mock = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $this->mock = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $this->conn = new WampConnection($this->mock);
     }
 
@@ -67,7 +67,7 @@ class WampConnectionTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testClose() {
-        $mock = $this->getMock('\\Ratchet\\ConnectionInterface');
+        $mock = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $conn = new WampConnection($mock);
 
         $mock->expects($this->once())->method('close');

--- a/tests/unit/Wamp/WampServerTest.php
+++ b/tests/unit/Wamp/WampServerTest.php
@@ -7,7 +7,7 @@ use Ratchet\AbstractMessageComponentTestCase;
  */
 class WampServerTest extends AbstractMessageComponentTestCase {
     public function getConnectionClassString() {
-        return '\Ratchet\Wamp\WampConnection';
+        return 'Ratchet\Wamp\WampConnection';
     }
 
     public function getDecoratorClassString() {
@@ -15,7 +15,7 @@ class WampServerTest extends AbstractMessageComponentTestCase {
     }
 
     public function getComponentClassString() {
-        return '\Ratchet\Wamp\WampServerInterface';
+        return 'Ratchet\Wamp\WampServerInterface';
     }
 
     public function testOnMessageToEvent() {
@@ -23,7 +23,7 @@ class WampServerTest extends AbstractMessageComponentTestCase {
 
         $this->_app->expects($this->once())->method('onPublish')->with(
             $this->isExpectedConnection()
-          , new \PHPUnit_Framework_Constraint_IsInstanceOf('\Ratchet\Wamp\Topic')
+          , new \PHPUnit_Framework_Constraint_IsInstanceOf('Ratchet\Wamp\Topic')
           , $published
           , array()
           , array()

--- a/tests/unit/Wamp/WampServerTest.php
+++ b/tests/unit/Wamp/WampServerTest.php
@@ -23,7 +23,7 @@ class WampServerTest extends AbstractMessageComponentTestCase {
 
         $this->_app->expects($this->once())->method('onPublish')->with(
             $this->isExpectedConnection()
-          , new \PHPUnit_Framework_Constraint_IsInstanceOf('Ratchet\Wamp\Topic')
+          , $this->isInstanceOf('Ratchet\Wamp\Topic')
           , $published
           , array()
           , array()


### PR DESCRIPTION
This changeset updates the tests to support PHPUnit ^7.5 and the latest psr/http-message on PHP 7.2+. This is part 3 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite will continue to work as is, but will use newer PHPUnit versions on newer PHP versions. Once merged, I'll use this as a starting point to add newer PHP 8+ version support as discussed in https://github.com/ratchetphp/Ratchet/issues/1003 and elsewhere.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1091 and #1088, one large step closer to reviving Ratchet as discussed in #1054