### PR TITLE
Update tests to support PHPUnit ^9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
           dependency-versions: "${{ matrix.dependencies }}"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit"
+        run: "vendor/bin/phpunit ${{ matrix.php-version < 7.3 && ' -c phpunit.xml.legacy' || '' }}"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     }
 }

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         cacheResult="false"
          colors="true">
     <testsuites>
-        <testsuite name="Ratchet test suite">
+        <testsuite name="Ratchet Test Suite">
             <directory>./tests/unit/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
+++ b/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
@@ -12,7 +12,10 @@ abstract class AbstractMessageComponentTestCase extends TestCase {
     abstract public function getDecoratorClassString();
     abstract public function getComponentClassString();
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->_app  = $this->getMockBuilder($this->getComponentClassString())->getMock();
         $decorator   = $this->getDecoratorClassString();
         $this->_serv = new $decorator($this->_app);

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -12,7 +12,10 @@ class AbstractConnectionDecoratorTest extends TestCase {
     protected $l1;
     protected $l2;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->mock = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->l1   = new ConnectionDecorator($this->mock);
         $this->l2   = new ConnectionDecorator($this->l1);
@@ -132,41 +135,44 @@ class AbstractConnectionDecoratorTest extends TestCase {
     }
 
     public function testWarningGettingNothing() {
-        if (!(error_reporting() & E_NOTICE)) {
-            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
-        }
+        $error = false;
+        set_error_handler(function () use (&$error) {
+            $error = true;
+        }, E_NOTICE);
 
-        if (method_exists($this, 'expectException')) {
-            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
-        } else {
-            $this->setExpectedException('PHPUnit_Framework_Error');
-        }
         $var = $this->mock->nonExistant;
+
+        restore_error_handler();
+
+        $this->assertTrue($error);
+        $this->assertNull($var);
     }
 
     public function testWarningGettingNothingLevel1() {
-        if (!(error_reporting() & E_NOTICE)) {
-            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
-        }
+        $error = false;
+        set_error_handler(function () use (&$error) {
+            $error = true;
+        }, E_NOTICE);
 
-        if (method_exists($this, 'expectException')) {
-            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
-        } else {
-            $this->setExpectedException('PHPUnit_Framework_Error');
-        }
         $var = $this->l1->nonExistant;
+
+        restore_error_handler();
+
+        $this->assertTrue($error);
+        $this->assertNull($var);
     }
 
     public function testWarningGettingNothingLevel2() {
-        if (!(error_reporting() & E_NOTICE)) {
-            $this->markTestSkipped('Requires error_reporting to include E_NOTICE');
-        }
+        $error = false;
+        set_error_handler(function () use (&$error) {
+            $error = true;
+        }, E_NOTICE);
 
-        if (method_exists($this, 'expectException')) {
-            $this->expectException(class_exists('PHPUnit\Framework\Error\Error') ? 'PHPUnit\Framework\Error\Error' : 'PHPUnit_Framework_Error');
-        } else {
-            $this->setExpectedException('PHPUnit_Framework_Error');
-        }
         $var = $this->l2->nonExistant;
+
+        restore_error_handler();
+
+        $this->assertTrue($error);
+        $this->assertNull($var);
     }
 }

--- a/tests/unit/Http/HttpRequestParserTest.php
+++ b/tests/unit/Http/HttpRequestParserTest.php
@@ -9,7 +9,10 @@ use PHPUnit\Framework\TestCase;
 class HttpRequestParserTest extends TestCase {
     protected $parser;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpParser() {
         $this->parser = new HttpRequestParser;
     }
 

--- a/tests/unit/Http/HttpServerTest.php
+++ b/tests/unit/Http/HttpServerTest.php
@@ -6,8 +6,11 @@ use Ratchet\AbstractMessageComponentTestCase;
  * @covers Ratchet\Http\HttpServer
  */
 class HttpServerTest extends AbstractMessageComponentTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * @before
+     */
+    public function setUpConnection() {
+        parent::setUpConnection();
         $this->_conn->httpHeadersReceived = true;
     }
 

--- a/tests/unit/Http/OriginCheckTest.php
+++ b/tests/unit/Http/OriginCheckTest.php
@@ -8,11 +8,14 @@ use Ratchet\AbstractMessageComponentTestCase;
 class OriginCheckTest extends AbstractMessageComponentTestCase {
     protected $_reqStub;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->_reqStub = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $this->_reqStub->expects($this->any())->method('getHeader')->will($this->returnValue(['localhost']));
 
-        parent::setUp();
+        parent::setUpConnection();
 
         assert($this->_serv instanceof OriginCheck);
         $this->_serv->allowedOrigins[] = 'localhost';

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -18,7 +18,10 @@ class RouterTest extends TestCase {
     protected $_uri;
     protected $_req;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->_uri  = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
         $this->_req  = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();

--- a/tests/unit/Server/EchoServerTest.php
+++ b/tests/unit/Server/EchoServerTest.php
@@ -7,7 +7,10 @@ class EchoServerTest extends TestCase {
     protected $_conn;
     protected $_comp;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpServer() {
         $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->_comp = new EchoServer;
     }

--- a/tests/unit/Server/FlashPolicyComponentTest.php
+++ b/tests/unit/Server/FlashPolicyComponentTest.php
@@ -10,7 +10,10 @@ class FlashPolicyTest extends TestCase {
 
     protected $_policy;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpPolicy() {
         $this->_policy = new FlashPolicy();
     }
 

--- a/tests/unit/Server/IoConnectionTest.php
+++ b/tests/unit/Server/IoConnectionTest.php
@@ -10,7 +10,10 @@ class IoConnectionTest extends TestCase {
     protected $sock;
     protected $conn;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->sock = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
         $this->conn = new IoConnection($this->sock);
     }

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -25,7 +25,10 @@ class IoServerTest extends TestCase {
         $loop->run();
     }
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpServer() {
         $this->app = $this->getMockBuilder('Ratchet\\MessageComponentInterface')->getMock();
 
         $loop = new StreamSelectLoop;

--- a/tests/unit/Server/IpBlackListComponentTest.php
+++ b/tests/unit/Server/IpBlackListComponentTest.php
@@ -10,7 +10,10 @@ class IpBlackListTest extends TestCase {
     protected $blocker;
     protected $mock;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpBlocker() {
         $this->mock = $this->getMockBuilder('Ratchet\\MessageComponentInterface')->getMock();
         $this->blocker = new IpBlackList($this->mock);
     }

--- a/tests/unit/Session/Serialize/PhpHandlerTest.php
+++ b/tests/unit/Session/Serialize/PhpHandlerTest.php
@@ -9,7 +9,10 @@ use Ratchet\Session\Serialize\PhpHandler;
 class PhpHandlerTest extends TestCase {
     protected $_handler;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpHandler() {
         $this->_handler = new PhpHandler;
     }
 

--- a/tests/unit/Session/SessionComponentTest.php
+++ b/tests/unit/Session/SessionComponentTest.php
@@ -10,18 +10,24 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
  * @covers Ratchet\Session\Storage\Proxy\VirtualProxy
  */
 class SessionProviderTest extends AbstractMessageComponentTestCase {
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpProvider() {
         return $this->markTestIncomplete('Test needs to be updated for ini_set issue in PHP 7.2');
 
         if (!class_exists('Symfony\Component\HttpFoundation\Session\Session')) {
             return $this->markTestSkipped('Dependency of Symfony HttpFoundation failed');
         }
 
-        parent::setUp();
+        parent::setUpConnection();
         $this->_serv = new SessionProvider($this->_app, new NullSessionHandler);
     }
 
-    public function tearDown() {
+    /**
+     * @after
+     */
+    public function tearDownHandler() {
         ini_set('session.serialize_handler', 'php');
     }
 

--- a/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
+++ b/tests/unit/Session/Storage/VirtualSessionStoragePDOTest.php
@@ -14,7 +14,10 @@ class VirtualSessionStoragePDOTest extends TestCase {
 
     protected $_pathToDB;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpHandler() {
         if (!extension_loaded('PDO') || !extension_loaded('pdo_sqlite')) {
             return $this->markTestSkipped('Session test requires PDO and pdo_sqlite');
         }
@@ -42,7 +45,10 @@ SQL;
         $this->_virtualSessionStorage->registerBag(new AttributeBag());
     }
 
-    public function tearDown() {
+    /**
+     * @after
+     */
+    public function tearDownHandler() {
         unlink($this->_pathToDB);
     }
 

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -14,7 +14,10 @@ class ServerProtocolTest extends TestCase {
 
     protected $_app;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpProtocol() {
         $this->_app  = new TestComponent;
         $this->_comp = new ServerProtocol($this->_app);
     }

--- a/tests/unit/Wamp/TopicManagerTest.php
+++ b/tests/unit/Wamp/TopicManagerTest.php
@@ -19,7 +19,10 @@ class TopicManagerTest extends TestCase {
      */
     private $conn;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpManager() {
         $this->conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
         $this->mock = $this->getMockBuilder('Ratchet\Wamp\WampServerInterface')->getMock();
         $this->mngr = new TopicManager($this->mock);
@@ -214,7 +217,13 @@ class TopicManagerTest extends TestCase {
     }
 
     public function testGetSubProtocolsReturnsArray() {
-        $this->assertInternalType('array', $this->mngr->getSubProtocols());
+        if (method_exists($this, 'assertIsArray')) {
+            // PHPUnit 7+
+            $this->assertIsArray($this->mngr->getSubProtocols());
+        } else {
+            // legacy PHPUnit
+            $this->assertInternalType('array', $this->mngr->getSubProtocols());
+        }
     }
 
     public function testGetSubProtocolsBubbles() {

--- a/tests/unit/Wamp/WampConnectionTest.php
+++ b/tests/unit/Wamp/WampConnectionTest.php
@@ -10,7 +10,10 @@ class WampConnectionTest extends TestCase {
     protected $conn;
     protected $mock;
 
-    public function setUp() {
+    /**
+     * @before
+     */
+    public function setUpConnection() {
         $this->mock = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
         $this->conn = new WampConnection($this->mock);
     }

--- a/tests/unit/Wamp/WampServerTest.php
+++ b/tests/unit/Wamp/WampServerTest.php
@@ -34,7 +34,13 @@ class WampServerTest extends AbstractMessageComponentTestCase {
 
     public function testGetSubProtocols() {
         // todo: could expand on this
-        $this->assertInternalType('array', $this->_serv->getSubProtocols());
+        if (method_exists($this, 'assertIsArray')) {
+            // PHPUnit 7+
+            $this->assertIsArray($this->_serv->getSubProtocols());
+        } else {
+            // legacy PHPUnit
+            $this->assertInternalType('array', $this->_serv->getSubProtocols());
+        }
     }
 
     public function testConnectionClosesOnInvalidJson() {


### PR DESCRIPTION
This changeset updates the tests to support PHPUnit ^9.6. This is part 4 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite will continue to work as is, but will use newer PHPUnit versions on newer PHP versions. Once merged, I'll use this as a starting point to add newer PHP 8+ version support as discussed in https://github.com/ratchetphp/Ratchet/issues/1003 and elsewhere.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054