### PR TITLE
Full support for PHP 8.1 and PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+          - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ composer require cboden/ratchet:^0.4.4
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through PHP 7.4+ with limited support for PHP 8+.
+extensions and supports running on legacy PHP 5.4 through PHP 8.1+ with limited support for PHP 8.2+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 See above note about [Reviving Ratchet](#reviving-ratchet) for newer PHP support.

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0"
     }
 }

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -138,7 +138,7 @@ class AbstractConnectionDecoratorTest extends TestCase {
         $error = false;
         set_error_handler(function () use (&$error) {
             $error = true;
-        }, E_NOTICE);
+        }, PHP_VERSION_ID >= 80000 ? E_WARNING : E_NOTICE);
 
         $var = $this->mock->nonExistant;
 
@@ -152,7 +152,7 @@ class AbstractConnectionDecoratorTest extends TestCase {
         $error = false;
         set_error_handler(function () use (&$error) {
             $error = true;
-        }, E_NOTICE);
+        }, PHP_VERSION_ID >= 80000 ? E_WARNING : E_NOTICE);
 
         $var = $this->l1->nonExistant;
 
@@ -166,7 +166,7 @@ class AbstractConnectionDecoratorTest extends TestCase {
         $error = false;
         set_error_handler(function () use (&$error) {
             $error = true;
-        }, E_NOTICE);
+        }, PHP_VERSION_ID >= 80000 ? E_WARNING : E_NOTICE);
 
         $var = $this->l2->nonExistant;
 


### PR DESCRIPTION
This changeset adds full support for PHP 8.1 and PHP 8.0. This is part 5 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1092 and #1093 now works fine on PHP 8.1 and PHP 8.0 at least. Once merged, I'll use this as a starting point to add newer PHP 8.2+ version support as discussed in https://github.com/ratchetphp/Ratchet/issues/1003 and elsewhere.

Note that this temporarily pins symfony/http-foundation to < 6 for the tests only. The session storage methods are currently incompatible with HttpFoundation 6+ and #926 really shouldn't have been merged without more tests, see #969 for details. This is something I would like to address in a separate follow-up, as this shouldn't limit our ability to test PHP 8+ for the time being.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054