### PR TITLE
Update to properly support Symfony 6 (PHP 8+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     }
 }

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
@@ -26,7 +26,8 @@ class VirtualProxy extends SessionHandlerProxy {
     /**
      * {@inheritdoc}
      */
-    public function getId() {
+    #[HackSupportForSymfony6] public function getId(): string { /*
+    public function getId() { /**/
         return $this->_sessionId;
     }
 
@@ -40,7 +41,8 @@ class VirtualProxy extends SessionHandlerProxy {
     /**
      * {@inheritdoc}
      */
-    public function getName() {
+    #[HackSupportForSymfony6] public function getName(): string { /*
+    public function getName() { /**/
         return $this->_sessionName;
     }
 

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony6.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony6.php
@@ -2,13 +2,13 @@
 namespace Ratchet\Session\Storage\Proxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
-if (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','getId'))->hasReturnType()) {
-    // alias to class for Symfony 6 on PHP 8+ that uses native types like `getId(): string`
-    class_alias(__NAMESPACE__ . '\\VirtualProxyForSymfony6', __NAMESPACE__ . '\\VirtualProxy');
-} else {
-    // fall back to class without native types
-
-class VirtualProxy extends SessionHandlerProxy {
+/**
+ * [internal] VirtualProxy for Symfony 6 on PHP 8+ using native types like `getId(): string`
+ *
+ * @internal used internally only, should not be referenced directly
+ * @see VirtualProxy
+ */
+class VirtualProxyForSymfony6 extends SessionHandlerProxy {
     /**
      * @var string
      */
@@ -32,7 +32,7 @@ class VirtualProxy extends SessionHandlerProxy {
     /**
      * {@inheritdoc}
      */
-    public function getId() {
+    public function getId(): string {
         return $this->_sessionId;
     }
 
@@ -46,7 +46,7 @@ class VirtualProxy extends SessionHandlerProxy {
     /**
      * {@inheritdoc}
      */
-    public function getName() {
+    public function getName(): string {
         return $this->_sessionName;
     }
 
@@ -57,6 +57,4 @@ class VirtualProxy extends SessionHandlerProxy {
     public function setName($name) {
         throw new \RuntimeException("Can not change session name in VirtualProxy");
     }
-}
-
 }

--- a/src/Ratchet/Session/Storage/VirtualSessionStorage.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorage.php
@@ -25,7 +25,8 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function start() {
+    #[HackSupportForSymfony6] public function start(): bool { /*
+    public function start() { /**/
         if ($this->started && !$this->closed) {
             return true;
         }
@@ -51,8 +52,10 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function regenerate($destroy = false, $lifetime = null) {
+    #[HackSupportForSymfony6] public function regenerate(bool $destroy = false, ?int $lifetime = null): bool { /*
+    public function regenerate($destroy = false, $lifetime = null) { /**/
         // .. ?
+        return false;
     }
 
     /**

--- a/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony6.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony6.php
@@ -4,13 +4,13 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Ratchet\Session\Storage\Proxy\VirtualProxy;
 use Ratchet\Session\Serialize\HandlerInterface;
 
-if (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage','start'))->hasReturnType()) {
-    // alias to class for Symfony 6 on PHP 8+ that uses native types like `start(): bool`
-    class_alias(__NAMESPACE__ . '\\VirtualSessionStorageForSymfony6', __NAMESPACE__ . '\\VirtualSessionStorage');
-} else {
-    // fall back to class without native types
-
-class VirtualSessionStorage extends NativeSessionStorage {
+/**
+ * [internal] VirtualSessionStorage for Symfony 6 on PHP 8+ using native types like `start(): bool`
+ *
+ * @internal used internally only, should not be referenced directly
+ * @see VirtualSessionStorage
+ */
+class VirtualSessionStorageForSymfony6 extends NativeSessionStorage {
     /**
      * @var \Ratchet\Session\Serialize\HandlerInterface
      */
@@ -31,7 +31,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function start() {
+    public function start(): bool {
         if ($this->started && !$this->closed) {
             return true;
         }
@@ -57,7 +57,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function regenerate($destroy = false, $lifetime = null) {
+    public function regenerate(bool $destroy = false, ?int $lifetime = null): bool {
         // .. ?
         return false;
     }
@@ -92,6 +92,4 @@ class VirtualSessionStorage extends NativeSessionStorage {
 
         $this->saveHandler = $saveHandler;
     }
-}
-
 }


### PR DESCRIPTION
This changeset adds proper support for Symfony 6 on PHP 8+. This is part 6 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1094, #1093 and #1092 now confirms that Symfony 6 can successfully be used on PHP 8+. Symfony 6 support was originally merged in #926 a while ago without proper tests. As a result, the optional session component reported fatal errors when used with Symfony 6 on PHP 8+ as reported in #969 and others. Once merged, I'll use this as a starting point to add newer Symfony 7 version support as discussed in #1045 and elsewhere.

Note that the implementation involves two new classes used for Symfony 6 compatibility only as originally suggested by @josh-gaby in #1014. This PR doesn't directly apply from the other PR mainly due to its broader scope and complexity, but it applies some very similar ideas. While this duplication isn't exactly *perfect*, I think it's *good enough* to get this working again. Future PRs to avoid this duplication welcome.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1094, #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #969 and #963