### PR TITLE
Support PHP 8.2 and work around reporting dynamic properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         include:

--- a/README.md
+++ b/README.md
@@ -101,20 +101,9 @@ composer require cboden/ratchet:^0.4.4
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through PHP 8.2+ with limited support for PHP 8.2+.
+extensions and supports running on legacy PHP 5.4 through PHP 8.2+ with limited support for newer PHP.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
-Note that PHP 8.2+ has limited support due to a number of deprecation notices
-caused by dynamic property access. The code works without limitations otherwise,
-so for now, we recommend running without reporting deprecation notices like this:
-
-```php
-// Report all errors except E_DEPRECATED
-error_reporting(E_ALL & ~E_DEPRECATED);
-```
-
-Addressing these deprecation notices is on the roadmap for future releases, but
-requires major effort to refactor the codebase to avoid dynamic property access.
 See above note about [Reviving Ratchet](#reviving-ratchet) for newer PHP support.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -101,9 +101,20 @@ composer require cboden/ratchet:^0.4.4
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through PHP 8.1+ with limited support for PHP 8.2+.
+extensions and supports running on legacy PHP 5.4 through PHP 8.2+ with limited support for PHP 8.2+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
+Note that PHP 8.2+ has limited support due to a number of deprecation notices
+caused by dynamic property access. The code works without limitations otherwise,
+so for now, we recommend running without reporting deprecation notices like this:
+
+```php
+// Report all errors except E_DEPRECATED
+error_reporting(E_ALL & ~E_DEPRECATED);
+```
+
+Addressing these deprecation notices is on the roadmap for future releases, but
+requires major effort to refactor the codebase to avoid dynamic property access.
 See above note about [Reviving Ratchet](#reviving-ratchet) for newer PHP support.
 
 ## License

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,6 @@
         </include>
     </coverage>
     <php>
-        <!-- Report all errors except E_DEPRECATED -->
-        <ini name="error_reporting" value="24575" />
+        <ini name="error_reporting" value="-1" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,8 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          cacheResult="false"
-         colors="true">
+         colors="true"
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Ratchet test suite">
             <directory>./tests/unit/</directory>
@@ -16,4 +17,8 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <!-- Report all errors except E_DEPRECATED -->
+        <ini name="error_reporting" value="24575" />
+    </php>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -15,4 +15,7 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>

--- a/src/Ratchet/AbstractConnectionDecorator.php
+++ b/src/Ratchet/AbstractConnectionDecorator.php
@@ -4,6 +4,11 @@ namespace Ratchet;
 /**
  * Wraps ConnectionInterface objects via the decorator pattern but allows
  * parameters to bubble through with magic methods
+ *
+ * Note that this instance does not use the `#[\AllowDynamicProperties]`
+ * attribute for PHP 8.2+ compatibility as any properties added to this class
+ * will be forwarded to the wrapped instance.
+ *
  * @todo It sure would be nice if I could make most of this a trait...
  */
 abstract class AbstractConnectionDecorator implements ConnectionInterface {

--- a/src/Ratchet/ConnectionInterface.php
+++ b/src/Ratchet/ConnectionInterface.php
@@ -10,6 +10,12 @@ const VERSION = 'Ratchet/0.4.4';
 /**
  * A proxy object representing a connection to the application
  * This acts as a container to store data (in memory) about the connection
+ *
+ * Note that Ratchet makes heavy use of the decorator pattern and dynamic
+ * properties. This means any object that implements this interface may not
+ * have the same methods or properties as the ones in this interface.
+ * Implementations of this interface may have to use the `#[\AllowDynamicProperties]`
+ * attribute to allow dynamic properties on PHP 8.2+.
  */
 interface ConnectionInterface {
     /**

--- a/src/Ratchet/Server/IoConnection.php
+++ b/src/Ratchet/Server/IoConnection.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ratchet\Server;
 use Ratchet\ConnectionInterface;
-use React\Socket\ConnectionInterface as ReactConn;
+use React\Socket\ConnectionInterface as SocketConnection;
 
 /**
  * {@inheritdoc}
  */
+#[\AllowDynamicProperties]
 class IoConnection implements ConnectionInterface {
     /**
      * @var \React\Socket\ConnectionInterface
@@ -16,7 +17,7 @@ class IoConnection implements ConnectionInterface {
     /**
      * @param \React\Socket\ConnectionInterface $conn
      */
-    public function __construct(ReactConn $conn) {
+    public function __construct(SocketConnection $conn) {
         $this->conn = $conn;
     }
 

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Server;
 use Ratchet\MessageComponentInterface;
 use React\EventLoop\LoopInterface;
+use React\Socket\ConnectionInterface as SocketConnection;
 use React\Socket\ServerInterface;
 use React\EventLoop\Factory as LoopFactory;
 use React\Socket\Server as Reactor;
@@ -79,8 +80,13 @@ class IoServer {
      * Triggered when a new connection is received from React
      * @param \React\Socket\ConnectionInterface $conn
      */
-    public function handleConnect($conn) {
+    public function handleConnect(SocketConnection $conn) {
+        // assign dynamic `$decor` property used by Ratchet without raising notice on PHP 8.2+
+        // need this hack because we can't use `#[\AllowDynamicProperties]` on vendor code
+        set_error_handler(function () { }, E_DEPRECATED);
         $conn->decor = new IoConnection($conn);
+        restore_error_handler();
+
         $conn->decor->resourceId = (int)$conn->stream;
 
         $uri = $conn->getRemoteAddress();

--- a/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
+++ b/tests/helpers/Ratchet/AbstractMessageComponentTestCase.php
@@ -19,7 +19,7 @@ abstract class AbstractMessageComponentTestCase extends TestCase {
         $this->_app  = $this->getMockBuilder($this->getComponentClassString())->getMock();
         $decorator   = $this->getDecoratorClassString();
         $this->_serv = new $decorator($this->_app);
-        $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->_conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
 
         $this->doOpen($this->_conn);
     }
@@ -34,7 +34,7 @@ abstract class AbstractMessageComponentTestCase extends TestCase {
 
     public function testOpen() {
         $this->_app->expects($this->once())->method('onOpen')->with($this->isExpectedConnection());
-        $this->doOpen($this->getMockBuilder('Ratchet\ConnectionInterface')->getMock());
+        $this->doOpen($this->getMockBuilder('Ratchet\Mock\Connection')->getMock());
     }
 
     public function testOnClose() {

--- a/tests/helpers/Ratchet/Mock/Connection.php
+++ b/tests/helpers/Ratchet/Mock/Connection.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Mock;
 use Ratchet\ConnectionInterface;
 
+#[\AllowDynamicProperties]
 class Connection implements ConnectionInterface {
     public $last = array(
         'send'  => ''

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -16,7 +16,7 @@ class AbstractConnectionDecoratorTest extends TestCase {
      * @before
      */
     public function setUpConnection() {
-        $this->mock = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->mock = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $this->l1   = new ConnectionDecorator($this->mock);
         $this->l2   = new ConnectionDecorator($this->l1);
     }

--- a/tests/unit/Http/HttpRequestParserTest.php
+++ b/tests/unit/Http/HttpRequestParserTest.php
@@ -35,7 +35,7 @@ class HttpRequestParserTest extends TestCase {
     }
 
     public function testBufferOverflowResponse() {
-        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
 
         $this->parser->maxSize = 20;
 
@@ -51,7 +51,7 @@ class HttpRequestParserTest extends TestCase {
     }
 
     public function testReturnTypeIsRequest() {
-        $conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $return = $this->parser->onMessage($conn, "GET / HTTP/1.1\r\nHost: socketo.me\r\n\r\n");
 
         $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $return);

--- a/tests/unit/Http/RouterTest.php
+++ b/tests/unit/Http/RouterTest.php
@@ -22,7 +22,7 @@ class RouterTest extends TestCase {
      * @before
      */
     public function setUpConnection() {
-        $this->_conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->_conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $this->_uri  = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
         $this->_req  = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $this->_req
@@ -80,7 +80,7 @@ class RouterTest extends TestCase {
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));
         $this->_router->onOpen($this->_conn, $this->_req);
 
-        $expectedConn = $this->isInstanceOf('Ratchet\ConnectionInterface');
+        $expectedConn = $this->isInstanceOf('Ratchet\Mock\Connection');
         $controller->expects($this->once())->method('onOpen')->with($expectedConn, $this->_req);
 
         $this->_matcher->expects($this->any())->method('match')->will($this->returnValue(array('_controller' => $controller)));

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -117,7 +117,12 @@ class IoServerTest extends TestCase {
 
     public function testOnErrorPassesException() {
         $conn = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
+
+        // assign dynamic property without raising notice on PHP 8.2+
+        set_error_handler(function () { }, E_DEPRECATED);
         $conn->decor = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
+        restore_error_handler();
+
         $err  = new \Exception("Nope");
 
         $this->app->expects($this->once())->method('onError')->with($conn->decor, $err);

--- a/tests/unit/Server/IpBlackListComponentTest.php
+++ b/tests/unit/Server/IpBlackListComponentTest.php
@@ -121,7 +121,7 @@ class IpBlackListTest extends TestCase {
     }
 
     protected function newConn() {
-        $conn = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
+        $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $conn->remoteAddress = '127.0.0.1';
 
         return $conn;

--- a/tests/unit/Wamp/TopicManagerTest.php
+++ b/tests/unit/Wamp/TopicManagerTest.php
@@ -23,7 +23,7 @@ class TopicManagerTest extends TestCase {
      * @before
      */
     public function setUpManager() {
-        $this->conn = $this->getMockBuilder('Ratchet\ConnectionInterface')->getMock();
+        $this->conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $this->mock = $this->getMockBuilder('Ratchet\Wamp\WampServerInterface')->getMock();
         $this->mngr = new TopicManager($this->mock);
 

--- a/tests/unit/Wamp/TopicTest.php
+++ b/tests/unit/Wamp/TopicTest.php
@@ -42,8 +42,8 @@ class TopicTest extends TestCase {
         $name = 'Batman';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
-        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
 
         $first->expects($this->once())
               ->method('send')
@@ -65,9 +65,9 @@ class TopicTest extends TestCase {
         $name = 'Excluding';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
-        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
-        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
+        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
 
         $first->expects($this->once())
             ->method('send')
@@ -92,9 +92,9 @@ class TopicTest extends TestCase {
         $name = 'Eligible';
         $protocol = json_encode(array(8, $name, $msg));
 
-        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
-        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
-        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock()))->getMock();
+        $first  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
+        $second = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
+        $third  = $this->getMockBuilder('Ratchet\\Wamp\\WampConnection')->setMethods(array('send'))->setConstructorArgs(array($this->getMockBuilder('Ratchet\Mock\Connection')->getMock()))->getMock();
 
         $first->expects($this->once())
             ->method('send')
@@ -161,6 +161,6 @@ class TopicTest extends TestCase {
     }
 
     protected function newConn() {
-        return new WampConnection($this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock());
+        return new WampConnection($this->getMockBuilder('Ratchet\Mock\Connection')->getMock());
     }
 }

--- a/tests/unit/Wamp/WampConnectionTest.php
+++ b/tests/unit/Wamp/WampConnectionTest.php
@@ -14,7 +14,7 @@ class WampConnectionTest extends TestCase {
      * @before
      */
     public function setUpConnection() {
-        $this->mock = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
+        $this->mock = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $this->conn = new WampConnection($this->mock);
     }
 
@@ -72,7 +72,7 @@ class WampConnectionTest extends TestCase {
     }
 
     public function testClose() {
-        $mock = $this->getMockBuilder('Ratchet\\ConnectionInterface')->getMock();
+        $mock = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $conn = new WampConnection($mock);
 
         $mock->expects($this->once())->method('close');


### PR DESCRIPTION
This changeset adds support for PHP 8.2 and works around reporting any dynamic properties. This is part 7 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1094, #1093 and #1092 now works fine on PHP 8.2 at last. Once merged, I'll use this as a starting point to add newer PHP 8.3+ version support as discussed in https://github.com/ratchetphp/Ratchet/issues/1003 and elsewhere.

Together with the recent Symfony 6 improvements from #1095, this PR also unblocks upcoming support for Symfony 7 (which requires PHP 8.2+). Once both are merged, I'll use this as a starting point to add newer Symfony 7 version support as discussed in #1045 and elsewhere.

Note that this employs a number of workarounds to support avoid raising deprecation notices when assigning dynamic properties on PHP 8.2+. Most notably, this makes use of the `#[\AllowDynamicProperties]` attribute where needed, plus a custom error handler ignoring notices where dynamic properties are used on vendor code. While this isn't exactly *perfect*, I think it's *good enough* to get this working on newer PHP versions again without applying a major refactoring and introducing any BC breaks. Future PRs to improve this very much welcome.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1094, #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054