### PR TITLE
Support PHP 8.3 and work around unserialize warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         dependencies:
           - "highest"
         include:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ composer require cboden/ratchet:^0.4.4
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.4 through PHP 8.2+ with limited support for newer PHP.
+extensions and supports running on legacy PHP 5.4 through PHP 8.3+ with limited support for newer PHP.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 See above note about [Reviving Ratchet](#reviving-ratchet) for newer PHP support.

--- a/src/Ratchet/Session/Serialize/PhpBinaryHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpBinaryHandler.php
@@ -22,7 +22,10 @@ class PhpBinaryHandler implements HandlerInterface {
             $offset += 1;
             $varname = substr($raw, $offset, $num);
             $offset += $num;
-            $data    = unserialize(substr($raw, $offset));
+
+            // try to unserialize one piece of data from current offset, ignoring any warnings for trailing data on PHP 8.3+
+            // @link https://wiki.php.net/rfc/unserialize_warn_on_trailing_data
+            $data = @unserialize(substr($raw, $offset));
 
             $returnData[$varname] = $data;
             $offset += strlen(serialize($data));

--- a/src/Ratchet/Session/Serialize/PhpHandler.php
+++ b/src/Ratchet/Session/Serialize/PhpHandler.php
@@ -38,7 +38,10 @@ class PhpHandler implements HandlerInterface {
             $num     = $pos - $offset;
             $varname = substr($raw, $offset, $num);
             $offset += $num + 1;
-            $data    = unserialize(substr($raw, $offset));
+
+            // try to unserialize one piece of data from current offset, ignoring any warnings for trailing data on PHP 8.3+
+            // @link https://wiki.php.net/rfc/unserialize_warn_on_trailing_data
+            $data = @unserialize(substr($raw, $offset));
 
             $returnData[$varname] = $data;
             $offset += strlen(serialize($data));

--- a/tests/unit/Session/Serialize/PhpBinaryHandlerTest.php
+++ b/tests/unit/Session/Serialize/PhpBinaryHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Ratchet\Session\Serialize;
+use PHPUnit\Framework\TestCase;
+use Ratchet\Session\Serialize\PhpBinaryHandler;
+
+/**
+ * @covers Ratchet\Session\Serialize\PhpHandler
+ */
+class PhpBinaryHandlerTest extends TestCase {
+    protected $_handler;
+
+    /**
+     * @before
+     */
+    public function setUpHandler() {
+        $this->_handler = new PhpBinaryHandler;
+    }
+
+    public function serializedProvider() {
+        return array(
+            array(
+                "\x0f" . '_sf2_attributes' . 'a:2:{s:5:"hello";s:5:"world";s:4:"last";i:1332872102;}' . "\x0c" . '_sf2_flashes' . 'a:0:{}'
+              , array(
+                    '_sf2_attributes' => array(
+                        'hello' => 'world'
+                      , 'last'  => 1332872102
+                    )
+                  , '_sf2_flashes' => array()
+                )
+            )
+        );
+    }
+
+    /**
+     * @dataProvider serializedProvider
+     */
+    public function testUnserialize($in, $expected) {
+        $this->assertEquals($expected, $this->_handler->unserialize($in));
+    }
+}


### PR DESCRIPTION
This changeset adds support for PHP 8.3 and works around reporting any unserialize warnings for trailing data. This is part 8 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1096, #1094, #1093 and #1092 now works fine on PHP 8.3 at last. In particular, this works around warnings reported due to https://wiki.php.net/rfc/unserialize_warn_on_trailing_data (not to be confused with https://wiki.php.net/rfc/improve_unserialize_error_handling) as reported in #1076 and others. Once merged, I'll use this as a starting point to add newer PHP 8.4+ version support as discussed in https://github.com/ratchetphp/Ratchet/issues/1003 and elsewhere.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1096, #1094, #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #1076