### PR TITLE
Update to support Symfony 7 (PHP 8.2+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "react/event-loop": ">=0.4"
       , "guzzlehttp/psr7": "^1.7|^2.0"
-      , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0|^6.0"
-      , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0"
+      , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
+      , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
     }
   , "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
@@ -2,8 +2,11 @@
 namespace Ratchet\Session\Storage\Proxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
-if (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','getId'))->hasReturnType()) {
-    // alias to class for Symfony 6 on PHP 8+ that uses native types like `getId(): string`
+if (PHP_VERSION_ID > 80200 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','setId'))->hasReturnType()) {
+    // alias to class for Symfony 7 on PHP 8.2+ using native types like `setId(string $id): void`
+    class_alias(__NAMESPACE__ . '\\VirtualProxyForSymfony7', __NAMESPACE__ . '\\VirtualProxy');
+} elseif (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','getId'))->hasReturnType()) {
+    // alias to class for Symfony 6 on PHP 8+ using native types like `getId(): string`
     class_alias(__NAMESPACE__ . '\\VirtualProxyForSymfony6', __NAMESPACE__ . '\\VirtualProxy');
 } else {
     // fall back to class without native types

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony7.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony7.php
@@ -1,0 +1,60 @@
+<?php
+namespace Ratchet\Session\Storage\Proxy;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
+
+/**
+ * [internal] VirtualProxy for Symfony 7 on PHP 8.2+ using native types like `setId(string $id): void`
+ *
+ * @internal used internally only, should not be referenced directly
+ * @see VirtualProxy
+ */
+class VirtualProxyForSymfony7 extends SessionHandlerProxy {
+    /**
+     * @var string
+     */
+    protected $_sessionId;
+
+    /**
+     * @var string
+     */
+    protected $_sessionName;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(\SessionHandlerInterface $handler) {
+        parent::__construct($handler);
+
+        $this->saveHandlerName = 'user';
+        $this->_sessionName    = ini_get('session.name');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId(): string {
+        return $this->_sessionId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setId(string $id): void {
+        $this->_sessionId = $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string {
+        return $this->_sessionName;
+    }
+
+    /**
+     * DO NOT CALL THIS METHOD
+     * @internal
+     */
+    public function setName(string $name): void {
+        throw new \RuntimeException("Can not change session name in VirtualProxy");
+    }
+}

--- a/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony7.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony7.php
@@ -1,19 +1,17 @@
 <?php
 namespace Ratchet\Session\Storage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
 use Ratchet\Session\Storage\Proxy\VirtualProxy;
 use Ratchet\Session\Serialize\HandlerInterface;
 
-if (PHP_VERSION_ID > 80200 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage','save'))->hasReturnType()) {
-    // alias to class for Symfony 7 on PHP 8.2+ using native types like `save(): void`
-    class_alias(__NAMESPACE__ . '\\VirtualSessionStorageForSymfony7', __NAMESPACE__ . '\\VirtualSessionStorage');
-} elseif (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage','start'))->hasReturnType()) {
-    // alias to class for Symfony 6 on PHP 8+ using native types like `start(): bool`
-    class_alias(__NAMESPACE__ . '\\VirtualSessionStorageForSymfony6', __NAMESPACE__ . '\\VirtualSessionStorage');
-} else {
-    // fall back to class without native types
-
-class VirtualSessionStorage extends NativeSessionStorage {
+/**
+ * [internal] VirtualSessionStorage for Symfony 7 on PHP 8.2+ using native types like `save(): void`
+ *
+ * @internal used internally only, should not be referenced directly
+ * @see VirtualSessionStorage
+ */
+class VirtualSessionStorageForSymfony7 extends NativeSessionStorage {
     /**
      * @var \Ratchet\Session\Serialize\HandlerInterface
      */
@@ -34,7 +32,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function start() {
+    public function start(): bool {
         if ($this->started && !$this->closed) {
             return true;
         }
@@ -60,7 +58,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function regenerate($destroy = false, $lifetime = null) {
+    public function regenerate(bool $destroy = false, ?int $lifetime = null): bool {
         // .. ?
         return false;
     }
@@ -68,7 +66,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function save() {
+    public function save(): void {
         // get the data from the bags?
         // serialize the data
         // save the data using the saveHandler
@@ -84,7 +82,7 @@ class VirtualSessionStorage extends NativeSessionStorage {
     /**
      * {@inheritdoc}
      */
-    public function setSaveHandler($saveHandler = null) {
+    public function setSaveHandler(AbstractProxy|\SessionHandlerInterface|null $saveHandler): void {
         if (!($saveHandler instanceof \SessionHandlerInterface)) {
             throw new \InvalidArgumentException('Handler must be instance of SessionHandlerInterface');
         }
@@ -95,6 +93,4 @@ class VirtualSessionStorage extends NativeSessionStorage {
 
         $this->saveHandler = $saveHandler;
     }
-}
-
 }


### PR DESCRIPTION
This changeset adds support for Symfony 7 on PHP 8.2+. This is part 9 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1096, #1095, #1094, #1093 and #1092 now confirms that Symfony 7 can successfully be used on PHP 8.2+. This builds on top of the recent fixes for Symfony 6 in #1095 and any related test suite improvements. Once merged, this would conclude the recent Symfony improvements, but there's still work to be done to support newer PHP versions as suggested in #1097 and elsewhere.

Note that the implementation involves two new classes used for Symfony 7 compatibility only as already done for Symfony 6 support in #1095 and as originally suggested by @josh-gaby in #1014. This PR doesn't directly apply from the other PR mainly due to its broader scope and complexity, but it applies some very similar ideas. While this duplication isn't exactly *perfect*, I think it's *good enough* to get this up to date again. Future PRs to avoid this duplication welcome.

Overall, this still requires a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1096, #1095, #1094, #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #1045