### PR TITLE
Add sponsor button to Ratchet

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+github: 
+    - ReactPHP
+    - clue 
+    - cboden


### PR DESCRIPTION
Adds a sponsor button to get faster access to sponsor profiles. 

![image](https://github.com/user-attachments/assets/9b9c0215-ed7d-425a-971d-d73d977f6bfd)

refs #1054 and #1100
 