### PR TITLE
Add issue templates to emphasize discussions over issues 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -1,0 +1,23 @@
+name: "🐛 Bug Report"
+description: "Found a bug in our project? Create a report to help us improve."
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for helping improve Ratchet by reporting a bug! 
+    Please check [existing Issues](https://github.com/ratchetphp/Ratchet/issues) before submitting."
+  
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: "Reproduction Steps"
+      description: "Exact steps to reproduce (include code samples)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Runtime Environment"
+      placeholder: "PHP version, Ratchet version, etc."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Ratchet Discussions"
+    url: https://github.com/ratchetphp/Ratchet/discussions
+    about: 'We are happy to answer your questions! Start a new discussion in our "Q&A" category.'
+  - name: "Feature Requests"
+    url: https://github.com/ratchetphp/Ratchet/discussions/categories/ideas
+    about: 'You have ideas to improve our project? Start a new discussion in our "Ideas" category.'


### PR DESCRIPTION
Add issue templates to emphasize discussions over issues. refs #1103, #1100 and #1054 
Builds on top of https://github.com/reactphp/.github/pull/3

Sample output: 
![image](https://github.com/user-attachments/assets/7e93d09d-513f-4be1-911f-a12503b92ed9)

![image](https://github.com/user-attachments/assets/fb427364-80b1-4a52-ab29-378131db7c62)
