### PR TITLE
Update to use global default loop with react/event-loop v1.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=5.4.2"
       , "ratchet/rfc6455": "^0.3.1"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
-      , "react/event-loop": ">=0.4"
+      , "react/event-loop": "^1.0 || ^0.5 || ^0.4"
       , "guzzlehttp/psr7": "^1.7|^2.0"
       , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"

--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -1,7 +1,8 @@
 <?php
 namespace Ratchet;
+use React\EventLoop\Factory as LegacyLoopFactory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Factory as LoopFactory;
 use React\Socket\Server as Reactor;
 use React\Socket\SecureServer as SecureReactor;
 use Ratchet\Http\HttpServerInterface;
@@ -72,7 +73,8 @@ class App {
         }
 
         if (null === $loop) {
-            $loop = LoopFactory::create();
+            // prefer default Loop (reactphp/event-loop v1.2+) over legacy \React\EventLoop\Factory
+            $loop = class_exists('React\EventLoop\Loop') ? Loop::get() : LegacyLoopFactory::create();
         }
 
         $this->httpHost = $httpHost;

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -1,10 +1,11 @@
 <?php
 namespace Ratchet\Server;
 use Ratchet\MessageComponentInterface;
+use React\EventLoop\Factory as LegacyLoopFactory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Socket\ConnectionInterface as SocketConnection;
 use React\Socket\ServerInterface;
-use React\EventLoop\Factory as LoopFactory;
 use React\Socket\Server as Reactor;
 use React\Socket\SecureServer as SecureReactor;
 
@@ -14,7 +15,7 @@ use React\Socket\SecureServer as SecureReactor;
  */
 class IoServer {
     /**
-     * @var \React\EventLoop\LoopInterface
+     * @var ?\React\EventLoop\LoopInterface
      */
     public $loop;
 
@@ -60,7 +61,9 @@ class IoServer {
      * @return IoServer
      */
     public static function factory(MessageComponentInterface $component, $port = 80, $address = '0.0.0.0') {
-        $loop   = LoopFactory::create();
+        // prefer default Loop (reactphp/event-loop v1.2+) over legacy \React\EventLoop\Factory
+        $loop = class_exists('React\EventLoop\Loop') ? Loop::get() : LegacyLoopFactory::create();
+
         $socket = new Reactor($address . ':' . $port, $loop);
 
         return new static($component, $socket, $loop);

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -111,7 +111,10 @@ class IoServerTest extends TestCase {
     }
 
     public function testFactory() {
-        $this->assertInstanceOf('Ratchet\\Server\\IoServer', IoServer::factory($this->app, 0));
+        $server = IoServer::factory($this->app, 0);
+        $server->socket->close();
+
+        $this->assertInstanceOf('Ratchet\\Server\\IoServer', $server);
     }
 
     public function testNoLoopProvidedError() {


### PR DESCRIPTION
This changeset updates to use the global default loop when available with react/event-loop v1.2+. This is part 11 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

Among others, this changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop) and avoids deprecated APIs (https://github.com/reactphp/event-loop/pull/226 and upcoming https://github.com/reactphp/event-loop/pull/274). For most consumers of this package, this change should not have any visible effect, given the old `Factory` sets the global `Loop` internally. Similar to #1095 and #1098, this was implemented in a way to use the newer API when available and the legacy APIs as a fallback. The test suite confirms this has full test coverage and does not otherwise affect any of the existing tests. In case this affects your usage, you may still pass an explicit loop instance to restore the previous behavior.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of https://github.com/reactphp/event-loop/pull/226, 6512da0, #1098, #1095, #1088 and others, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #956