### PR TITLE
Update to use new `SocketServer` API with react/socket v1.9+

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -3,8 +3,8 @@ namespace Ratchet;
 use React\EventLoop\Factory as LegacyLoopFactory;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Socket\Server as Reactor;
-use React\Socket\SecureServer as SecureReactor;
+use React\Socket\Server as LegacySocketServer;
+use React\Socket\SocketServer;
 use Ratchet\Http\HttpServerInterface;
 use Ratchet\Http\OriginCheck;
 use Ratchet\Wamp\WampServerInterface;
@@ -80,7 +80,8 @@ class App {
         $this->httpHost = $httpHost;
         $this->port = $port;
 
-        $socket = new Reactor($address . ':' . $port, $loop, $context);
+        // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server
+        $socket = class_exists('React\Socket\SocketServer') ? new SocketServer($address . ':' . $port, $context, $loop) : new LegacySocketServer($address . ':' . $port, $loop, $context);
 
         $this->routes  = new RouteCollection;
         $this->_server = new IoServer(new HttpServer(new Router(new UrlMatcher($this->routes, new RequestContext))), $socket, $loop);
@@ -94,7 +95,9 @@ class App {
         } else {
             $flashUri = 8843;
         }
-        $flashSock = new Reactor($flashUri, $loop);
+
+        // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server
+        $flashSock = class_exists('React\Socket\SocketServer') ? new SocketServer($flashUri, [], $loop) : new LegacySocketServer($flashUri, $loop);
         $this->flashServer = new IoServer($policy, $flashSock);
     }
 

--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -5,9 +5,9 @@ use React\EventLoop\Factory as LegacyLoopFactory;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Socket\ConnectionInterface as SocketConnection;
+use React\Socket\Server as LegacySocketServer;
 use React\Socket\ServerInterface;
-use React\Socket\Server as Reactor;
-use React\Socket\SecureServer as SecureReactor;
+use React\Socket\SocketServer;
 
 /**
  * Creates an open-ended socket to listen on a port for incoming connections.
@@ -64,7 +64,8 @@ class IoServer {
         // prefer default Loop (reactphp/event-loop v1.2+) over legacy \React\EventLoop\Factory
         $loop = class_exists('React\EventLoop\Loop') ? Loop::get() : LegacyLoopFactory::create();
 
-        $socket = new Reactor($address . ':' . $port, $loop);
+        // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server
+        $socket = class_exists('React\Socket\SocketServer') ? new SocketServer($address . ':' . $port, [], $loop) : new LegacySocketServer($address . ':' . $port, $loop);
 
         return new static($component, $socket, $loop);
     }

--- a/tests/autobahn/bin/fuzzingserver.php
+++ b/tests/autobahn/bin/fuzzingserver.php
@@ -22,7 +22,9 @@ class BinaryEcho implements \Ratchet\WebSocket\MessageComponentInterface {
     $impl = sprintf('React\EventLoop\%sLoop', $argc > 2 ? $argv[2] : 'StreamSelect');
 
     $loop = new $impl;
-    $sock = new React\Socket\Server('0.0.0.0:' . $port, $loop);
+
+    // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server
+    $sock = class_exists('React\Socket\SocketServer') ? new React\Socket\SocketServer('0.0.0.0:' . $port, [], $loop) : new React\Socket\Server('0.0.0.0:' . $port, $loop);
 
     $wsServer = new Ratchet\WebSocket\WsServer(new BinaryEcho);
     // This is enabled to test https://github.com/ratchetphp/Ratchet/issues/430

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -3,7 +3,8 @@ namespace Ratchet\Server;
 use PHPUnit\Framework\TestCase;
 use React\EventLoop\StreamSelectLoop;
 use React\EventLoop\LoopInterface;
-use React\Socket\Server;
+use React\Socket\Server as LegacySocketServer;
+use React\Socket\SocketServer;
 
 /**
  * @covers Ratchet\Server\IoServer
@@ -32,7 +33,9 @@ class IoServerTest extends TestCase {
         $this->app = $this->getMockBuilder('Ratchet\\MessageComponentInterface')->getMock();
 
         $loop = new StreamSelectLoop;
-        $this->reactor = new Server(0, $loop);
+
+        // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server
+        $this->reactor = class_exists('React\Socket\SocketServer') ? new SocketServer('127.0.0.1:0', [], $loop) : new LegacySocketServer('127.0.0.1:0', $loop);
 
         $uri = $this->reactor->getAddress();
         $this->port   = parse_url((strpos($uri, '://') === false ? 'tcp://' : '') . $uri, PHP_URL_PORT);


### PR DESCRIPTION
This changeset updates to use the new `SocketServer` API available with react/socket v1.9+. This is part 12 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

This is mostly done to avoid using deprecated APIs (https://github.com/reactphp/socket/pull/263 and upcoming https://github.com/reactphp/socket/pull/314) and should not have any visible effect for consumers of this package. Similar to #1105 and #1095 and #1098, this was implemented in a way to use the newer API when available and the legacy APIs as a fallback. The test suite confirms this has full test coverage and does not otherwise affect any of the existing tests.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of https://github.com/reactphp/socket/pull/263, #1105, #1098, #1095, #1088, #485 and others, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #917
Resolves / closes #1038