### PR TITLE
Fix compatibility with react/socket v1.9+ in `App` for `FlashPolicy`

### DIFF
--- a/src/Ratchet/App.php
+++ b/src/Ratchet/App.php
@@ -93,7 +93,7 @@ class App {
         if (80 == $port) {
             $flashUri = '0.0.0.0:843';
         } else {
-            $flashUri = 8843;
+            $flashUri = '127.0.0.1:8843';
         }
 
         // prefer SocketServer (reactphp/socket v1.9+) over legacy \React\Socket\Server

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -3,6 +3,7 @@ namespace Ratchet;
 
 use PHPUnit\Framework\TestCase;
 use Ratchet\App;
+use Ratchet\Server\IoServer;
 
 class AppTest extends TestCase {
     public function testCtorThrowsForInvalidLoop() {
@@ -13,5 +14,23 @@ class AppTest extends TestCase {
             $this->setExpectedException('InvalidArgumentException', 'Argument #4 ($loop) expected null|React\EventLoop\LoopInterface');
         }
         new App('localhost', 8080, '127.0.0.1', 'loop');
+    }
+
+    public function testCtorWithoutArgumentsStartsListeningOnDefaultPorts() {
+        if (@stream_socket_server('127.0.0.1:8080') === false || @stream_socket_server('127.0.0.1:8843') === false) {
+            $this->markTestSkipped('Default socket port 8080 or 8843 not available or already in use');
+        }
+        $app = new App();
+
+        $ref = new \ReflectionProperty($app, '_server');
+        $ref->setAccessible(true);
+        $server = $ref->getValue($app);
+        assert($server instanceof IoServer);
+
+        $this->assertStringMatchesFormat('%S127.0.0.1:8080', $server->socket->getAddress());
+        $this->assertStringMatchesFormat('%S127.0.0.1:8843', $app->flashServer->socket->getAddress());
+
+        $server->socket->close();
+        $app->flashServer->socket->close();
     }
 }


### PR DESCRIPTION
This changeset fixes compatibility with react/socket v1.9+ in `App` for the legacy `FlashPolicy`. This fixes a small oversight from #1106 merged a couple of weeks ago into the main branch, so this has not been released yet.

This wasn't caught by the previous tests because the `App` class was mostly untested. I've updated the tests to ensure this should not happen again. The test suite confirms this now has full test coverage and does not otherwise affect any of the existing tests.

Builds on top of #1106
Refs #1054