### PR TITLE
Assign empty remote address if socket address is unknown (Unix sockets) on PHP 8.1+

### DIFF
--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -97,7 +97,7 @@ class IoServer {
 
         $conn->decor->resourceId = (int)$conn->stream;
 
-        $uri = $conn->getRemoteAddress();
+        $uri = (string) $conn->getRemoteAddress();
         $conn->decor->remoteAddress = trim(
             parse_url((strpos($uri, '://') === false ? 'tcp://' : '') . $uri, PHP_URL_HOST),
             '[]'

--- a/tests/unit/Server/IoServerTest.php
+++ b/tests/unit/Server/IoServerTest.php
@@ -63,6 +63,23 @@ class IoServerTest extends TestCase {
         //$this->assertTrue(is_int($this->app->last['onOpen'][0]->resourceId));
     }
 
+    public function testHandleOpenWithoutRemoteAddressAssignsEmptyRemoteAddress() {
+        $this->app->expects($this->once())->method('onOpen')->with($this->isInstanceOf('Ratchet\\ConnectionInterface'));
+
+        $conn = $this->getMockBuilder('React\\Socket\\ConnectionInterface')->getMock();
+        $conn->expects($this->once())->method('getRemoteAddress')->willReturn(null);
+
+        // assign dynamic property without raising notice on PHP 8.2+
+        set_error_handler(function () { }, E_DEPRECATED);
+        $conn->stream = STDOUT;
+        restore_error_handler();
+
+        $this->server->handleConnect($conn);
+
+        $this->assertSame('', $conn->decor->remoteAddress);
+        $this->assertSame((int) STDOUT, $conn->decor->resourceId);
+    }
+
     /**
      * @requires extension sockets
      */


### PR DESCRIPTION
This changeset assigns an empty remote address if socket address is unknown (Unix sockets) on PHP 8.1+. This is in line with the existing behavior on older PHP versions. This is part 11 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

Similar to #1107, this wasn't caught by the previous tests because the `IoServer` doesn't have full test coverage. I've updated the tests to ensure this should not happen again. This builds on top of recent workarounds introduced with #1096 and others. The test suite confirms this now has full test coverage and does not otherwise affect any of the existing tests.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1094, #1096 and others, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #1036