### PR TITLE
Fix warning when handling HTTP request with missing `Origin` header

### DIFF
--- a/src/Ratchet/Http/OriginCheck.php
+++ b/src/Ratchet/Http/OriginCheck.php
@@ -33,7 +33,7 @@ class OriginCheck implements HttpServerInterface {
      */
     #[HackSupportForPHP8] public function onOpen(ConnectionInterface $conn, ?RequestInterface $request = null) { /*
     public function onOpen(ConnectionInterface $conn, RequestInterface $request = null) { /**/
-        $header = (string)$request->getHeader('Origin')[0];
+        $header = $request->getHeaderLine('Origin');
         $origin = parse_url($header, PHP_URL_HOST) ?: $header;
 
         if (!in_array($origin, $this->allowedOrigins)) {

--- a/tests/unit/Http/OriginCheckTest.php
+++ b/tests/unit/Http/OriginCheckTest.php
@@ -13,7 +13,7 @@ class OriginCheckTest extends AbstractMessageComponentTestCase {
      */
     public function setUpConnection() {
         $this->_reqStub = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
-        $this->_reqStub->expects($this->any())->method('getHeader')->will($this->returnValue(['localhost']));
+        $this->_reqStub->expects($this->any())->method('getHeaderLine')->with('Origin')->willReturn('localhost');
 
         parent::setUpConnection();
 
@@ -40,6 +40,24 @@ class OriginCheckTest extends AbstractMessageComponentTestCase {
     public function testCloseOnNonMatchingOrigin() {
         $this->_serv->allowedOrigins = ['socketo.me'];
         $this->_conn->expects($this->once())->method('close');
+
+        $this->_serv->onOpen($this->_conn, $this->_reqStub);
+    }
+
+    public function testCloseOnMissingOrigin() {
+        $this->_serv->allowedOrigins = ['socketo.me'];
+        $this->_conn->expects($this->once())->method('close');
+
+        $this->_reqStub->expects($this->once())->method('getHeaderLine')->with('Origin')->willReturn('');
+
+        $this->_serv->onOpen($this->_conn, $this->_reqStub);
+    }
+
+    public function testCloseOnDuplicateOrigin() {
+        $this->_serv->allowedOrigins = ['socketo.me'];
+        $this->_conn->expects($this->once())->method('close');
+
+        $this->_reqStub->expects($this->once())->method('getHeaderLine')->with('Origin')->willReturn('http://socketo.me,https://socketo.me');
 
         $this->_serv->onOpen($this->_conn, $this->_reqStub);
     }


### PR DESCRIPTION
This changeset fixes a warning when handling an HTTP request missing an `Origin` request header. A request without the required headers will not pass the `OriginCheck`, but it should not report a warning in either case. This is part 12 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

The code in question hasn't been touched in a while. This condition used to cause a notice in legacy PHP < 8 and a warning as of PHP 8+ (https://3v4l.org/8uKnY). Since adding full PHP 8+ support with #1094, we should properly handle this in either case. Similar to #1107 and others, this wasn't caught by the previous tests because the `OriginCheck` doesn't have full test coverage. I've updated the tests to ensure this should not happen again. The test suite confirms this now has full test coverage and does not otherwise affect any of the existing tests.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1094, and others, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #954