### PR TITLE
Fix rejecting invalid HTTP request starting with newlines

### DIFF
--- a/src/Ratchet/Http/HttpRequestParser.php
+++ b/src/Ratchet/Http/HttpRequestParser.php
@@ -51,7 +51,7 @@ class HttpRequestParser implements MessageInterface {
      * @return boolean
      */
     public function isEom($message) {
-        return (boolean)strpos($message, static::EOM);
+        return strpos($message, static::EOM) !== false;
     }
 
     /**

--- a/tests/unit/Http/HttpRequestParserTest.php
+++ b/tests/unit/Http/HttpRequestParserTest.php
@@ -50,6 +50,18 @@ class HttpRequestParserTest extends TestCase {
         $this->parser->onMessage($conn, "Header-Is: Too Big");
     }
 
+    public function testOnMessageThrowsExceptionForEmptyNewlines() {
+        $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            $this->setExpectedException('InvalidArgumentException');
+        }
+
+        $this->parser->onMessage($conn, "\r\n\r\n");
+    }
+
     public function testReturnTypeIsRequest() {
         $conn = $this->getMockBuilder('Ratchet\Mock\Connection')->getMock();
         $return = $this->parser->onMessage($conn, "GET / HTTP/1.1\r\nHost: socketo.me\r\n\r\n");


### PR DESCRIPTION
This changeset fixes rejecting invalid HTTP requests starting with empty newlines. This is part 13 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

The code in question hasn't been touched in a while. The idea is to start parsing HTTP headers when a double newline is encountered and the same logic should trigger if the buffer starts with a double newline. Accordingly, this will now properly reject such invalid requests and should not otherwise affect any valid HTTP requests. I've updated the tests to ensure this should not happen again. The test suite confirms this now has full test coverage and does not otherwise affect any of the existing tests.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1092 and others, one step closer to reviving Ratchet as discussed in #1054
Resolves / closes #334