### PR TITLE
Allow usage of ratchet/rfc6455 0.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   , "require": {
         "php": ">=5.4.2"
-      , "ratchet/rfc6455": "^0.3.1"
+      , "ratchet/rfc6455": "^0.4.0 | ^0.3.1"
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "react/event-loop": "^1.0 || ^0.5 || ^0.4"
       , "guzzlehttp/psr7": "^1.7|^2.0"

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -14,6 +14,7 @@ use Ratchet\RFC6455\Messaging\CloseFrameChecker;
 use Ratchet\RFC6455\Handshake\ServerNegotiator;
 use Ratchet\RFC6455\Handshake\RequestVerifier;
 use React\EventLoop\LoopInterface;
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Message;
 
 /**
@@ -86,7 +87,13 @@ class WsServer implements HttpServerInterface {
         $this->connections = new \SplObjectStorage;
 
         $this->closeFrameChecker   = new CloseFrameChecker;
-        $this->handshakeNegotiator = new ServerNegotiator(new RequestVerifier);
+
+        if (self::isRFC6455v03()) {
+            $this->handshakeNegotiator = new ServerNegotiator(new RequestVerifier);
+        } else {
+            $this->handshakeNegotiator = new ServerNegotiator(new RequestVerifier, new HttpFactory);
+        }
+
         $this->handshakeNegotiator->setStrictSubProtocolCheck(true);
 
         if ($component instanceof WsServerInterface) {
@@ -99,6 +106,11 @@ class WsServer implements HttpServerInterface {
         $this->ueFlowFactory = function() use ($reusableUnderflowException) {
             return $reusableUnderflowException;
         };
+    }
+
+    private static function isRFC6455v03() {
+        $reflection = new \ReflectionClass('Ratchet\RFC6455\Handshake\ServerNegotiator');
+        return $reflection->getMethod('__construct')->getNumberOfRequiredParameters() === 1;
     }
 
     /**


### PR DESCRIPTION
ratchet/rfc6455 as a new required param in the constructor of ServerNegotiator which is breaking the code. As this project still supports very old php versions we need to keep support for 0.3 but also include support for 0.4. Reflection is used to check for the correct version.

The option of using composer's new version checks is not possible as the older versions of composer do not have this class.