### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
       , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
     }
   , "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36"
     }
 }


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes as discussed in https://github.com/clue/reactphp-redis/pull/180. This is part 14 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

Builds on top of https://github.com/clue/reactphp-redis/pull/180 and #1099, #1092 and others