### PR TITLE
Support PHP 8.5 and work around deprecated method aliases and casts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         dependencies:
           - "highest"
         include:
@@ -33,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 2
 
@@ -45,7 +46,7 @@ jobs:
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/src/Ratchet/Server/FlashPolicy.php
+++ b/src/Ratchet/Server/FlashPolicy.php
@@ -66,7 +66,7 @@ class FlashPolicy implements MessageComponentInterface {
            throw new \UnexpectedValueException('Invalid Port');
         }
 
-        $this->_access[]   = array($domain, $ports, (boolean)$secure);
+        $this->_access[]   = array($domain, $ports, (bool)$secure);
         $this->_cacheValid = false;
 
         return $this;

--- a/src/Ratchet/Wamp/ServerProtocol.php
+++ b/src/Ratchet/Wamp/ServerProtocol.php
@@ -72,7 +72,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
      */
     public function onOpen(ConnectionInterface $conn) {
         $decor = new WampConnection($conn);
-        $this->connections->attach($conn, $decor);
+        $this->connections->offsetSet($conn, $decor);
 
         $this->_decorating->onOpen($decor);
     }
@@ -125,7 +125,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
             case static::MSG_PUBLISH:
                 $exclude  = (array_key_exists(3, $json) ? $json[3] : null);
                 if (!is_array($exclude)) {
-                    if (true === (boolean)$exclude) {
+                    if (true === (bool)$exclude) {
                         $exclude = [$from->WAMP->sessionId];
                     } else {
                         $exclude = [];
@@ -147,7 +147,7 @@ class ServerProtocol implements MessageComponentInterface, WsServerInterface {
      */
     public function onClose(ConnectionInterface $conn) {
         $decor = $this->connections[$conn];
-        $this->connections->detach($conn);
+        $this->connections->offsetUnset($conn);
 
         $this->_decorating->onClose($decor);
     }

--- a/src/Ratchet/Wamp/Topic.php
+++ b/src/Ratchet/Wamp/Topic.php
@@ -58,7 +58,7 @@ class Topic implements \IteratorAggregate, \Countable {
      * @return boolean
      */
     public function has(ConnectionInterface $conn) {
-        return $this->subscribers->contains($conn);
+        return $this->subscribers->offsetExists($conn);
     }
 
     /**
@@ -66,7 +66,7 @@ class Topic implements \IteratorAggregate, \Countable {
      * @return Topic
      */
     public function add(ConnectionInterface $conn) {
-        $this->subscribers->attach($conn);
+        $this->subscribers->offsetSet($conn);
 
         return $this;
     }
@@ -76,8 +76,8 @@ class Topic implements \IteratorAggregate, \Countable {
      * @return Topic
      */
     public function remove(ConnectionInterface $conn) {
-        if ($this->subscribers->contains($conn)) {
-            $this->subscribers->detach($conn);
+        if ($this->subscribers->offsetExists($conn)) {
+            $this->subscribers->offsetUnset($conn);
         }
 
         return $this;

--- a/src/Ratchet/Wamp/TopicManager.php
+++ b/src/Ratchet/Wamp/TopicManager.php
@@ -39,12 +39,12 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     public function onSubscribe(ConnectionInterface $conn, $topic) {
         $topicObj = $this->getTopic($topic);
 
-        if ($conn->WAMP->subscriptions->contains($topicObj)) {
+        if ($conn->WAMP->subscriptions->offsetExists($topicObj)) {
             return;
         }
 
         $this->topicLookup[$topic]->add($conn);
-        $conn->WAMP->subscriptions->attach($topicObj);
+        $conn->WAMP->subscriptions->offsetSet($topicObj);
         $this->app->onSubscribe($conn, $topicObj);
     }
 
@@ -54,7 +54,7 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     public function onUnsubscribe(ConnectionInterface $conn, $topic) {
         $topicObj = $this->getTopic($topic);
 
-        if (!$conn->WAMP->subscriptions->contains($topicObj)) {
+        if (!$conn->WAMP->subscriptions->offsetExists($topicObj)) {
             return;
         }
 
@@ -112,8 +112,8 @@ class TopicManager implements WsServerInterface, WampServerInterface {
     }
 
     protected function cleanTopic(Topic $topic, ConnectionInterface $conn) {
-        if ($conn->WAMP->subscriptions->contains($topic)) {
-            $conn->WAMP->subscriptions->detach($topic);
+        if ($conn->WAMP->subscriptions->offsetExists($topic)) {
+            $conn->WAMP->subscriptions->offsetUnset($topic);
         }
 
         $this->topicLookup[$topic->getId()]->remove($conn);

--- a/src/Ratchet/WebSocket/WsServer.php
+++ b/src/Ratchet/WebSocket/WsServer.php
@@ -150,7 +150,7 @@ class WsServer implements HttpServerInterface {
             $this->ueFlowFactory
         );
 
-        $this->connections->attach($conn, new ConnContext($wsConn, $streamer));
+        $this->connections->offsetSet($conn, new ConnContext($wsConn, $streamer));
 
         return $this->delegate->onOpen($wsConn);
     }
@@ -170,9 +170,9 @@ class WsServer implements HttpServerInterface {
      * {@inheritdoc}
      */
     public function onClose(ConnectionInterface $conn) {
-        if ($this->connections->contains($conn)) {
+        if ($this->connections->offsetExists($conn)) {
             $context = $this->connections[$conn];
-            $this->connections->detach($conn);
+            $this->connections->offsetUnset($conn);
 
             $this->delegate->onClose($context->connection);
         }
@@ -182,7 +182,7 @@ class WsServer implements HttpServerInterface {
      * {@inheritdoc}
      */
     public function onError(ConnectionInterface $conn, \Exception $e) {
-        if ($this->connections->contains($conn)) {
+        if ($this->connections->offsetExists($conn)) {
             $this->delegate->onError($this->connections[$conn]->connection, $e);
         } else {
             $conn->close();
@@ -215,7 +215,7 @@ class WsServer implements HttpServerInterface {
 
         $this->pongReceiver = function(FrameInterface $frame, $wsConn) use ($pingedConnections, &$lastPing) {
             if ($frame->getPayload() === $lastPing->getPayload()) {
-                $pingedConnections->detach($wsConn);
+                $pingedConnections->offsetUnset($wsConn);
             }
         };
 
@@ -231,7 +231,7 @@ class WsServer implements HttpServerInterface {
                 $wsConn  = $this->connections[$conn]->connection;
 
                 $wsConn->send($lastPing);
-                $pingedConnections->attach($wsConn);
+                $pingedConnections->offsetSet($wsConn);
             }
         });
    }

--- a/tests/unit/AbstractConnectionDecoratorTest.php
+++ b/tests/unit/AbstractConnectionDecoratorTest.php
@@ -90,7 +90,9 @@ class AbstractConnectionDecoratorTest extends TestCase {
     public function testGetConnection() {
         $class  = new \ReflectionClass('Ratchet\\AbstractConnectionDecorator');
         $method = $class->getMethod('getConnection');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $conn = $method->invokeArgs($this->l1, array());
 
@@ -100,7 +102,9 @@ class AbstractConnectionDecoratorTest extends TestCase {
     public function testGetConnectionLevel2() {
         $class  = new \ReflectionClass('Ratchet\\AbstractConnectionDecorator');
         $method = $class->getMethod('getConnection');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $conn = $method->invokeArgs($this->l2, array());
 

--- a/tests/unit/AppTest.php
+++ b/tests/unit/AppTest.php
@@ -23,7 +23,9 @@ class AppTest extends TestCase {
         $app = new App();
 
         $ref = new \ReflectionProperty($app, '_server');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $server = $ref->getValue($app);
         assert($server instanceof IoServer);
 

--- a/tests/unit/Session/SessionProviderTest.php
+++ b/tests/unit/Session/SessionProviderTest.php
@@ -66,7 +66,9 @@ class SessionProviderTest extends AbstractMessageComponentTestCase {
     public function testToClassCase($in, $out) {
         $ref = new \ReflectionClass('Ratchet\\Session\\SessionProvider');
         $method = $ref->getMethod('toClassCase');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $component = new SessionProvider($this->getMockBuilder($this->getComponentClassString())->getMock(), $this->getMockBuilder('SessionHandlerInterface')->getMock());
         $this->assertEquals($out, $method->invokeArgs($component, array($in)));

--- a/tests/unit/Wamp/ServerProtocolTest.php
+++ b/tests/unit/Wamp/ServerProtocolTest.php
@@ -190,7 +190,9 @@ class ServerProtocolTest extends TestCase {
 
         $class  = new \ReflectionClass('Ratchet\\Wamp\\WampConnection');
         $method = $class->getMethod('getConnection');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $check = $method->invokeArgs($this->_app->last['onClose'][0], array());
 
@@ -207,7 +209,9 @@ class ServerProtocolTest extends TestCase {
 
         $class  = new \ReflectionClass('Ratchet\\Wamp\\WampConnection');
         $method = $class->getMethod('getConnection');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $check = $method->invokeArgs($this->_app->last['onError'][0], array());
 

--- a/tests/unit/Wamp/TopicManagerTest.php
+++ b/tests/unit/Wamp/TopicManagerTest.php
@@ -34,7 +34,9 @@ class TopicManagerTest extends TestCase {
     public function testGetTopicReturnsTopicObject() {
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array('The Topic'));
 
@@ -46,7 +48,9 @@ class TopicManagerTest extends TestCase {
 
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array($name));
 
@@ -56,7 +60,9 @@ class TopicManagerTest extends TestCase {
     public function testGetTopicReturnsSameObject() {
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array('No copy'));
         $again = $method->invokeArgs($this->mngr, array('No copy'));
@@ -95,13 +101,15 @@ class TopicManagerTest extends TestCase {
 
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array($name));
 
         $this->mngr->onSubscribe($this->conn, $name);
 
-        $this->assertTrue($this->conn->WAMP->subscriptions->contains($topic));
+        $this->assertTrue($this->conn->WAMP->subscriptions->offsetExists($topic));
     }
 
     public function testDoubleSubscriptionFiresOnce() {
@@ -135,14 +143,16 @@ class TopicManagerTest extends TestCase {
 
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array($name));
 
         $this->mngr->onSubscribe($this->conn, $name);
         $this->mngr->onUnsubscribe($this->conn, $name);
 
-        $this->assertFalse($this->conn->WAMP->subscriptions->contains($topic));
+        $this->assertFalse($this->conn->WAMP->subscriptions->offsetExists($topic));
     }
 
     public function testOnPublishBubbles() {
@@ -167,10 +177,14 @@ class TopicManagerTest extends TestCase {
     protected function topicProvider($name) {
         $class  = new \ReflectionClass('Ratchet\Wamp\TopicManager');
         $method = $class->getMethod('getTopic');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $attribute = $class->getProperty('topicLookup');
-        $attribute->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $attribute->setAccessible(true);
+        }
 
         $topic = $method->invokeArgs($this->mngr, array($name));
 


### PR DESCRIPTION
This changeset adds support for PHP 8.5 and works around deprecated method aliases and casts. This is part 15 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite recently updated with #1117, #1099, #1097, #1096, #1094, #1093 and #1092 now works fine on PHP 8.5 at last. This aligns with the broader PHP 8.5 rollout across the ReactPHP ecosystem, including the just-released `ratchet/rfc6455` v0.4.1 covering https://github.com/ratchetphp/RFC6455/pull/75 and https://github.com/ratchetphp/RFC6455/pull/77, plus recent upstream PHP 8.5 fixes in https://github.com/reactphp/socket/pull/325, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297 and related work. Thanks to Ratchet's existing multi-version constraints, no composer.json changes are needed. Composer transparently picks up these latest minor releases on PHP 8.5+ while remaining compatible with legacy PHP 5.4+ on older versions.

Specifically, this works around `SplObjectStorage::attach()`, `detach()`, and `contains()` method aliases (now using `offsetSet()`, `offsetUnset()`, and `offsetExists()` instead) and the non-canonical `(boolean)` cast (now using `(bool)` instead). The test suite also guards `ReflectionMethod`/`Property::setAccessible()` calls with `if (PHP_VERSION_ID < 80100)` since these became no-ops in PHP 8.1+ and were formally deprecated in PHP 8.5.

Overall, this required quite a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1117, #1099, #1097, #1096, #1094, #1093, #1092, #1091 and #1088, one step closer to reviving Ratchet as discussed in #1054