### PR TITLE
Update to support Symfony 8 (PHP 8.4+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
       , "react/socket": "^1.0 || ^0.8 || ^0.7 || ^0.6 || ^0.5"
       , "react/event-loop": "^1.0 || ^0.5 || ^0.4"
       , "guzzlehttp/psr7": "^1.7|^2.0"
-      , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
-      , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0"
+      , "symfony/http-foundation": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
+      , "symfony/routing": "^2.6|^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
     }
   , "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36"

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxy.php
@@ -3,7 +3,7 @@ namespace Ratchet\Session\Storage\Proxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
 if (PHP_VERSION_ID > 80200 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','setId'))->hasReturnType()) {
-    // alias to class for Symfony 7 on PHP 8.2+ using native types like `setId(string $id): void`
+    // alias to class for Symfony 7 on PHP 8.2+ and Symfony 8 on PHP 8.4+ using native types like `setId(string $id): void`
     class_alias(__NAMESPACE__ . '\\VirtualProxyForSymfony7', __NAMESPACE__ . '\\VirtualProxy');
 } elseif (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy','getId'))->hasReturnType()) {
     // alias to class for Symfony 6 on PHP 8+ using native types like `getId(): string`

--- a/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony7.php
+++ b/src/Ratchet/Session/Storage/Proxy/VirtualProxyForSymfony7.php
@@ -3,7 +3,7 @@ namespace Ratchet\Session\Storage\Proxy;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
 /**
- * [internal] VirtualProxy for Symfony 7 on PHP 8.2+ using native types like `setId(string $id): void`
+ * [internal] VirtualProxy for Symfony 7 on PHP 8.2+ and Symfony 8 on PHP 8.4+ using native types like `setId(string $id): void`
  *
  * @internal used internally only, should not be referenced directly
  * @see VirtualProxy

--- a/src/Ratchet/Session/Storage/VirtualSessionStorage.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorage.php
@@ -5,7 +5,7 @@ use Ratchet\Session\Storage\Proxy\VirtualProxy;
 use Ratchet\Session\Serialize\HandlerInterface;
 
 if (PHP_VERSION_ID > 80200 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage','save'))->hasReturnType()) {
-    // alias to class for Symfony 7 on PHP 8.2+ using native types like `save(): void`
+    // alias to class for Symfony 7 on PHP 8.2+ and Symfony 8 on PHP 8.4+ using native types like `save(): void`
     class_alias(__NAMESPACE__ . '\\VirtualSessionStorageForSymfony7', __NAMESPACE__ . '\\VirtualSessionStorage');
 } elseif (PHP_VERSION_ID > 80000 && (new \ReflectionMethod('Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage','start'))->hasReturnType()) {
     // alias to class for Symfony 6 on PHP 8+ using native types like `start(): bool`

--- a/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony7.php
+++ b/src/Ratchet/Session/Storage/VirtualSessionStorageForSymfony7.php
@@ -6,7 +6,7 @@ use Ratchet\Session\Storage\Proxy\VirtualProxy;
 use Ratchet\Session\Serialize\HandlerInterface;
 
 /**
- * [internal] VirtualSessionStorage for Symfony 7 on PHP 8.2+ using native types like `save(): void`
+ * [internal] VirtualSessionStorage for Symfony 7 on PHP 8.2+ and Symfony 8 on PHP 8.4+ using native types like `save(): void`
  *
  * @internal used internally only, should not be referenced directly
  * @see VirtualSessionStorage


### PR DESCRIPTION
This changeset adds support for Symfony 8 on PHP 8.4+. This is part 16 of reviving Ratchet as discussed in https://github.com/ratchetphp/Ratchet/issues/1054, unblocking more future progress.

With these changes applied, the existing test suite now confirms that Symfony 8 can successfully be used on PHP 8.4+. Unlike the recent Symfony 6 (#1095) and Symfony 7 (#1098) updates which each needed dedicated compatibility classes, Symfony 8 requires none: its method signatures match Symfony 7's, so the existing classes already apply. This only widens the `symfony/http-foundation` and `symfony/routing` constraints to allow `^8.0`. Thanks to Ratchet's multi-version constraints, Composer transparently picks up Symfony 8 on PHP 8.4+ while remaining compatible with legacy Symfony and PHP 5.4+ on older versions.

Overall, reviving Ratchet remains a massive effort. If you want to support this project, please consider [sponsoring @reactphp](https://github.com/sponsors/reactphp) ❤️

Builds on top of #1118 and #1098, one step closer to reviving Ratchet as discussed in #1054